### PR TITLE
feat: implement parquet market data loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ outputs/reports/*
 outputs/charts/*
 
 !.gitkeep
+
+test.py

--- a/src/data/downloader.py
+++ b/src/data/downloader.py
@@ -74,30 +74,63 @@ def standardize_ohlcv(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
     if df.empty:
         return pd.DataFrame()
 
+    df = df.copy()
+
+    # Handle MultiIndex columns from yfinance
+    if isinstance(df.columns, pd.MultiIndex):
+        flattened_columns = []
+        for col in df.columns:
+            if isinstance(col, tuple):
+                non_empty_parts = [str(part) for part in col if str(part).strip()]
+                flattened_columns.append("_".join(non_empty_parts))
+            else:
+                flattened_columns.append(str(col))
+        df.columns = flattened_columns
+    else:
+        df.columns = [str(col) for col in df.columns]
+
     df = df.reset_index()
 
-    # Normalize column names from yfinance
-    rename_map = {
-        "Date": "date",
-        "Datetime": "date",
-        "Open": "open",
-        "High": "high",
-        "Low": "low",
-        "Close": "close",
-        "Adj Close": "adj_close",
-        "Volume": "volume",
-        "Dividends": "dividends",
-        "Stock Splits": "stock_splits",
-    }
-    df = df.rename(columns=rename_map)
+    # Normalize column names
+    normalized_columns = {}
+    for col in df.columns:
+        col_lower = col.strip().lower()
 
-    # Some downloads may not contain actions columns depending on source/asset
-    if "dividends" not in df.columns:
-        df["dividends"] = 0.0
-    if "stock_splits" not in df.columns:
-        df["stock_splits"] = 0.0
+        if col_lower in ["date", "datetime"]:
+            normalized_columns[col] = "date"
+        elif col_lower.startswith("open"):
+            normalized_columns[col] = "open"
+        elif col_lower.startswith("high"):
+            normalized_columns[col] = "high"
+        elif col_lower.startswith("low"):
+            normalized_columns[col] = "low"
+        elif col_lower.startswith("close") and "adj" not in col_lower:
+            normalized_columns[col] = "close"
+        elif "adj" in col_lower and "close" in col_lower:
+            normalized_columns[col] = "adj_close"
+        elif col_lower.startswith("volume"):
+            normalized_columns[col] = "volume"
+        elif "dividend" in col_lower:
+            normalized_columns[col] = "dividends"
+        elif "split" in col_lower:
+            normalized_columns[col] = "stock_splits"
+
+    df = df.rename(columns=normalized_columns)
+
+    if "date" not in df.columns:
+        raise ValueError(f"Could not find date column for {symbol}. Columns: {list(df.columns)}")
+
+    if "close" not in df.columns:
+        raise ValueError(f"Could not find close column for {symbol}. Columns: {list(df.columns)}")
+
     if "adj_close" not in df.columns:
         df["adj_close"] = df["close"]
+
+    if "dividends" not in df.columns:
+        df["dividends"] = 0.0
+
+    if "stock_splits" not in df.columns:
+        df["stock_splits"] = 0.0
 
     df["symbol"] = symbol
     df["date"] = pd.to_datetime(df["date"]).dt.tz_localize(None)
@@ -122,7 +155,6 @@ def standardize_ohlcv(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
     df = df[ordered_columns].sort_values("date").reset_index(drop=True)
 
     return df
-
 
 def download_symbol_data(
     symbol: str,

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_DIR = REPO_ROOT / "config"
+RAW_DATA_DIR = REPO_ROOT / "data" / "raw"
+
+REQUIRED_COLUMNS = [
+    "date",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adj_close",
+    "volume",
+    "dividends",
+    "stock_splits",
+]
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file and return it as a dictionary."""
+    if not path.exists():
+        raise FileNotFoundError(f"Missing config file: {path}")
+
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid YAML structure in: {path}")
+
+    return data
+
+
+def load_settings() -> dict[str, Any]:
+    """Load settings.yaml."""
+    return load_yaml(CONFIG_DIR / "settings.yaml")
+
+
+def load_universe() -> list[str]:
+    """Load symbol list from universe.yaml."""
+    data = load_yaml(CONFIG_DIR / "universe.yaml")
+    symbols = data.get("universe", {}).get("symbols", [])
+
+    if not isinstance(symbols, list) or not symbols:
+        raise ValueError("No symbols found in config/universe.yaml")
+
+    cleaned = []
+    for symbol in symbols:
+        if isinstance(symbol, str) and symbol.strip():
+            cleaned.append(symbol.strip().upper())
+
+    if not cleaned:
+        raise ValueError("Universe symbol list is empty after cleaning.")
+
+    return cleaned
+
+
+def get_target_symbols() -> list[str]:
+    """Return universe symbols plus benchmark symbol if needed."""
+    settings = load_settings()
+    universe_symbols = load_universe()
+
+    benchmark_symbol = (
+        settings.get("benchmark", {}).get("symbol", "") or ""
+    ).strip().upper()
+
+    symbols = list(universe_symbols)
+    if benchmark_symbol and benchmark_symbol not in symbols:
+        symbols.append(benchmark_symbol)
+
+    return symbols
+
+
+def validate_schema(df: pd.DataFrame, symbol: str) -> None:
+    """Validate required schema for a single symbol dataframe."""
+    missing_columns = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing_columns:
+        raise ValueError(
+            f"Missing required columns for {symbol}: {', '.join(missing_columns)}"
+        )
+
+
+def read_symbol_parquet(symbol: str) -> pd.DataFrame:
+    """Read one symbol parquet file from data/raw/."""
+    file_path = RAW_DATA_DIR / f"{symbol}.parquet"
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"Missing parquet file for {symbol}: {file_path}")
+
+    df = pd.read_parquet(file_path)
+    validate_schema(df, symbol)
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"]).dt.tz_localize(None)
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+
+    numeric_columns = [
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+        "dividends",
+        "stock_splits",
+    ]
+    for col in numeric_columns:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    df = (
+        df[REQUIRED_COLUMNS]
+        .drop_duplicates(subset=["date", "symbol"], keep="last")
+        .sort_values(["symbol", "date"])
+        .reset_index(drop=True)
+    )
+
+    return df
+
+
+def load_market_data(symbols: list[str] | None = None) -> pd.DataFrame:
+    """
+    Load market data for all requested symbols and return one combined dataframe.
+    If symbols is None, read symbols from config.
+    """
+    target_symbols = symbols or get_target_symbols()
+
+    if not target_symbols:
+        raise ValueError("No target symbols provided for loading.")
+
+    frames: list[pd.DataFrame] = []
+    failed_symbols: list[str] = []
+
+    for symbol in target_symbols:
+        try:
+            df = read_symbol_parquet(symbol)
+            if df.empty:
+                failed_symbols.append(symbol)
+                continue
+            frames.append(df)
+        except Exception as exc:
+            print(f"[ERROR] Failed to load {symbol}: {exc}")
+            failed_symbols.append(symbol)
+
+    if not frames:
+        raise ValueError("No parquet files could be loaded successfully.")
+
+    combined = (
+        pd.concat(frames, ignore_index=True)
+        .sort_values(["date", "symbol"])
+        .reset_index(drop=True)
+    )
+
+    print("-" * 60)
+    print(f"Loaded symbols: {combined['symbol'].nunique()}")
+    print(f"Rows: {len(combined)}")
+    print(f"Date range: {combined['date'].min().date()} -> {combined['date'].max().date()}")
+
+    if failed_symbols:
+        print(f"Failed symbols: {', '.join(failed_symbols)}")
+
+    return combined
+
+
+def main() -> None:
+    df = load_market_data()
+    print(df.head())
+    print(df.tail())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #4

## What changed
- added src/data/loader.py
- implemented YAML-based symbol loading
- implemented parquet reading from data/raw/
- added schema validation for required market data columns
- combined all symbol files into one clean dataframe

## Why
This PR adds the first local data loading layer for Phase 1 and prepares the project for feature engineering.

## Validation
- loaded 11 symbols successfully
- combined dataset rows: 17083
- date range: 2020-01-02 to 2026-03-09