### PR TITLE
feat(engine): add next-day execution logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,3 @@ outputs/charts/*
 
 !.gitkeep
 
-test.py
-src/engine/test_portfolio_manual.py
-src/engine/test_broker_manual.py
-src/strategy/test_momentum_manual.py

--- a/src/data/features.py
+++ b/src/data/features.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 
 import pandas as pd
 

--- a/src/engine/broker.py
+++ b/src/engine/broker.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from dataclasses import dataclass, asdict
 from typing import Any
 

--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+import sys
 from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from dataclasses import asdict
 from typing import Any
 
 import pandas as pd
@@ -25,7 +31,7 @@ class DailySimulator:
     - Processes one trading day at a time in chronological order
     - For each decision date, only rows up to that date are visible
     - Target/label columns are removed before passing data to strategy
-    - Orders are executed using the same day's adj_close price
+    - Orders decided on day t are executed on the next trading day
     """
 
     def __init__(
@@ -46,6 +52,18 @@ class DailySimulator:
         self._positions_history: list[dict[str, Any]] = []
         self._trade_history: list[dict[str, Any]] = []
         self._signal_history: list[dict[str, Any]] = []
+        self._pending_signals: dict[pd.Timestamp, list[StrategySignal]] = {}
+
+    def _ensure_runtime_state(self) -> None:
+        """
+        Backward-compatible guard for runtime attributes.
+
+        Some environments may execute code with stale artifacts where newly added
+        attributes are missing at runtime. This method ensures required mutable
+        containers exist before simulation steps proceed.
+        """
+        if not hasattr(self, "_pending_signals") or self._pending_signals is None:
+            self._pending_signals = {}
 
     @staticmethod
     def _prepare_market_data(
@@ -123,9 +141,18 @@ class DailySimulator:
         row = asdict(signal)
         return row
 
-    def _record_signals(self, signals: list[StrategySignal]) -> None:
+    def _record_signals(
+        self,
+        signals: list[StrategySignal],
+        scheduled_execution_date: pd.Timestamp | None,
+        schedule_status: str,
+    ) -> None:
         for signal in signals:
-            self._signal_history.append(self._signal_to_row(signal))
+            row = self._signal_to_row(signal)
+            row["decision_date"] = pd.Timestamp(signal.date)
+            row["scheduled_execution_date"] = scheduled_execution_date
+            row["schedule_status"] = schedule_status
+            self._signal_history.append(row)
 
     def _record_daily_snapshots(
         self,
@@ -160,7 +187,7 @@ class DailySimulator:
     def _execute_sell_signals(
         self,
         signals: list[StrategySignal],
-        trading_date: pd.Timestamp,
+        execution_date: pd.Timestamp,
         price_map: dict[str, float],
     ) -> None:
         for signal in signals:
@@ -188,13 +215,15 @@ class DailySimulator:
             )
 
             row = result.to_dict()
-            row["date"] = trading_date
+            row["date"] = execution_date
+            row["decision_date"] = pd.Timestamp(signal.date)
+            row["execution_date"] = execution_date
             self._trade_history.append(row)
 
     def _execute_buy_signals(
         self,
         signals: list[StrategySignal],
-        trading_date: pd.Timestamp,
+        execution_date: pd.Timestamp,
         price_map: dict[str, float],
     ) -> None:
         buy_signals = [s for s in signals if str(s.action).upper() == "BUY"]
@@ -235,10 +264,69 @@ class DailySimulator:
             )
 
             row = result.to_dict()
-            row["date"] = trading_date
+            row["date"] = execution_date
+            row["decision_date"] = pd.Timestamp(signal.date)
+            row["execution_date"] = execution_date
             self._trade_history.append(row)
 
-    def _process_day(self, trading_date: pd.Timestamp) -> None:
+    @staticmethod
+    def _next_trading_date_map(
+        trading_dates: list[pd.Timestamp],
+    ) -> dict[pd.Timestamp, pd.Timestamp | None]:
+        next_map: dict[pd.Timestamp, pd.Timestamp | None] = {}
+        for idx, trading_date in enumerate(trading_dates):
+            next_map[trading_date] = trading_dates[idx + 1] if idx + 1 < len(trading_dates) else None
+        return next_map
+
+    def _schedule_signals(
+        self,
+        signals: list[StrategySignal],
+        next_execution_date: pd.Timestamp | None,
+    ) -> None:
+        if not signals:
+            return
+
+        if next_execution_date is None:
+            self._record_signals(
+                signals=signals,
+                scheduled_execution_date=None,
+                schedule_status="NO_NEXT_TRADING_SESSION",
+            )
+            return
+
+        self._record_signals(
+            signals=signals,
+            scheduled_execution_date=next_execution_date,
+            schedule_status="SCHEDULED",
+        )
+        self._pending_signals.setdefault(next_execution_date, []).extend(signals)
+
+    def _execute_pending_signals(self, execution_date: pd.Timestamp) -> None:
+        pending = self._pending_signals.pop(execution_date, [])
+        if not pending:
+            return
+
+        signals = self._sort_signals(pending)
+        price_map = self._day_prices(execution_date)
+
+        self._execute_sell_signals(
+            signals=signals,
+            execution_date=execution_date,
+            price_map=price_map,
+        )
+        self._execute_buy_signals(
+            signals=signals,
+            execution_date=execution_date,
+            price_map=price_map,
+        )
+
+    def _process_day(
+        self,
+        trading_date: pd.Timestamp,
+        next_execution_date: pd.Timestamp | None,
+    ) -> None:
+        self._execute_pending_signals(execution_date=trading_date)
+
         historical_data = self._history_until(trading_date)
 
         signals = self.strategy.generate_signals(
@@ -248,20 +336,12 @@ class DailySimulator:
         )
         signals = self._sort_signals(signals)
 
-        self._record_signals(signals)
+        self._schedule_signals(
+            signals=signals,
+            next_execution_date=next_execution_date,
+        )
 
         price_map = self._day_prices(trading_date)
-
-        self._execute_sell_signals(
-            signals=signals,
-            trading_date=trading_date,
-            price_map=price_map,
-        )
-        self._execute_buy_signals(
-            signals=signals,
-            trading_date=trading_date,
-            price_map=price_map,
-        )
 
         self._record_daily_snapshots(
             trading_date=trading_date,
@@ -285,10 +365,14 @@ class DailySimulator:
 
         if not trading_dates:
             raise ValueError("No trading dates found for the requested range.")
+        
+        next_date_map = self._next_trading_date_map(trading_dates)
 
         for trading_date in trading_dates:
-            self._process_day(trading_date)
-
+            self._process_day(
+                trading_date=trading_date,
+                next_execution_date=next_date_map.get(trading_date),
+            )
         portfolio_history = pd.DataFrame(self._portfolio_history)
         positions_history = pd.DataFrame(self._positions_history)
         trade_history = pd.DataFrame(self._trade_history)

--- a/src/engine/test_simulator_manual.py
+++ b/src/engine/test_simulator_manual.py
@@ -1,4 +1,11 @@
 from __future__ import annotations
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 
 import pandas as pd
 
@@ -15,7 +22,7 @@ class TwoStepStrategy(BaseStrategy):
             return [
                 StrategySignal(date=d, symbol="AAA", action="BUY", score=1.0, reason_code="TEST_BUY"),
             ]
-        if d == pd.Timestamp("2024-01-02") and portfolio.has_position("AAA"):
+        if d == pd.Timestamp("2024-01-03") and portfolio.has_position("AAA"):
             return [
                 StrategySignal(date=d, symbol="AAA", action="SELL", score=1.0, reason_code="TEST_SELL"),
             ]
@@ -25,23 +32,41 @@ class TwoStepStrategy(BaseStrategy):
 def main() -> None:
     data = pd.DataFrame(
         [
-            {"date": "2024-01-01", "symbol": "AAA", "open": 10.0, "close": 11.0},
-            {"date": "2024-01-02", "symbol": "AAA", "open": 12.0, "close": 12.0},
+            {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+            {"date": "2024-01-03", "symbol": "AAA", "adj_close": 12.0},
+            {"date": "2024-01-04", "symbol": "AAA", "adj_close": 11.0},
         ]
     )
 
     simulator = DailySimulator(
+        market_data=data,
         strategy=TwoStepStrategy(),
         broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
         portfolio=Portfolio(initial_cash=100.0),
-        max_position_weight=0.5,
+        price_column="adj_close",
     )
 
-    result = simulator.run(data)
+    result = simulator.run()
+    trades = result["trade_history"]
+    signals = result["signal_history"]
 
-    assert len(result.trades) == 2, "Expected one buy and one sell trade"
-    assert result.metrics["trade_count"] == 2
-    assert result.metrics["final_equity"] > 100.0
+    assert len(trades) == 2, "Expected one buy and one sell trade"
+
+    # Buy is decided on 2024-01-01 and executes on next trading day 2024-01-03.
+    first_trade = trades.iloc[0]
+    assert pd.Timestamp(first_trade["decision_date"]) == pd.Timestamp("2024-01-01")
+    assert pd.Timestamp(first_trade["execution_date"]) == pd.Timestamp("2024-01-03")
+
+    # Sell is decided on 2024-01-03 and executes on 2024-01-04.
+    second_trade = trades.iloc[1]
+    assert pd.Timestamp(second_trade["decision_date"]) == pd.Timestamp("2024-01-03")
+    assert pd.Timestamp(second_trade["execution_date"]) == pd.Timestamp("2024-01-04")
+
+    # Last-day signals are tracked but not executed when no future session exists.
+    last_signal = signals.sort_values("decision_date").iloc[-1]
+    assert last_signal["schedule_status"] in {"SCHEDULED", "NO_NEXT_TRADING_SESSION"}
+
+
     print("Simulator manual test passed.")
 
 

--- a/src/run_backtest.py
+++ b/src/run_backtest.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from src.data.features import add_basic_features
 from src.data.loader import load_market_data, load_settings

--- a/src/strategy/momentum.py
+++ b/src/strategy/momentum.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from typing import Any
 
 import pandas as pd

--- a/src/strategy/test_momentum_manual.py
+++ b/src/strategy/test_momentum_manual.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 import pandas as pd
 
 from src.data.features import add_basic_features


### PR DESCRIPTION
Closes #19

## What changed
- updated `src/engine/simulator.py`
- separated decision date and execution date in the simulation flow
- added next-available-session order execution logic
- executed orders using next-session market data instead of same-day prices
- handled final-date and missing-session edge cases safely
- improved trade history traceability with decision/execution timestamps

## Why
This PR makes the backtest engine time-safe by ensuring that signals generated on day `t` are executed on the next available trading session.

## Notes
The execution flow is kept reusable for future strategies and avoids same-day signal execution.