### PR TITLE
feat: convert strategy signals into executable orders

### DIFF
--- a/src/engine/order_builder.py
+++ b/src/engine/order_builder.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.engine.portfolio import Portfolio
+from src.strategy.base import StrategySignal
+
+
+@dataclass(frozen=True)
+class ExecutableOrder:
+    symbol: str
+    side: str
+    quantity: float
+    market_price: float
+
+    def to_broker_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": str(self.symbol),
+            "side": str(self.side).upper(),
+            "quantity": float(self.quantity),
+            "market_price": float(self.market_price),
+        }
+
+
+class OrderBuilder:
+    def __init__(
+        self,
+        max_open_positions: int,
+        max_position_size: float | None = None,
+        allow_add_to_existing: bool = False,
+        fractional_shares: bool = True,
+        commission_rate: float = 0.0,
+        slippage_rate: float = 0.0,
+    ) -> None:
+        if max_open_positions <= 0:
+            raise ValueError("max_open_positions must be positive")
+        if max_position_size is not None and (max_position_size <= 0 or max_position_size > 1.0):
+            raise ValueError("max_position_size must be in (0, 1]")
+
+        self.max_open_positions = int(max_open_positions)
+        self.max_position_size = (
+            float(max_position_size)
+            if max_position_size is not None
+            else 1.0 / float(self.max_open_positions)
+        )
+        self.allow_add_to_existing = bool(allow_add_to_existing)
+        self.fractional_shares = bool(fractional_shares)
+        self.commission_rate = float(commission_rate)
+        self.slippage_rate = float(slippage_rate)
+
+    @staticmethod
+    def _normalize_signal(signal: StrategySignal) -> dict[str, Any] | None:
+        symbol = str(getattr(signal, "symbol", "")).upper().strip()
+        action = str(getattr(signal, "action", "")).upper().strip()
+        score = float(getattr(signal, "score", 0.0) or 0.0)
+        target_weight = getattr(signal, "target_weight", None)
+
+        if not symbol or action not in {"BUY", "SELL", "HOLD"}:
+            return None
+
+        normalized_target = None
+        if target_weight is not None:
+            try:
+                tw = float(target_weight)
+                normalized_target = tw if tw > 0 else None
+            except (TypeError, ValueError):
+                normalized_target = None
+
+        return {
+            "symbol": symbol,
+            "action": action,
+            "score": score,
+            "target_weight": normalized_target,
+        }
+
+    def build_orders(
+        self,
+        signals: list[StrategySignal],
+        portfolio: Portfolio,
+        price_map: dict[str, float],
+        available_cash: float | None = None,
+    ) -> list[dict[str, Any]]:
+        if not signals:
+            return []
+
+        cash = float(portfolio.cash if available_cash is None else available_cash)
+        current_positions = {
+            symbol: position
+            for symbol, position in portfolio.positions.items()
+            if position.quantity > 0
+        }
+
+        normalized = [self._normalize_signal(s) for s in signals]
+        normalized = [s for s in normalized if s is not None]
+
+        sell_candidates = sorted(
+            [s for s in normalized if s["action"] == "SELL"],
+            key=lambda s: (-float(s["score"]), s["symbol"]),
+        )
+
+        sell_orders: list[ExecutableOrder] = []
+        sold_symbols: set[str] = set()
+        for signal in sell_candidates:
+            symbol = signal["symbol"]
+            if symbol in sold_symbols:
+                continue
+            position = current_positions.get(symbol)
+            market_price = price_map.get(symbol)
+            if position is None or position.quantity <= 0:
+                continue
+            if market_price is None or float(market_price) <= 0:
+                continue
+            sell_orders.append(
+                ExecutableOrder(
+                    symbol=symbol,
+                    side="SELL",
+                    quantity=float(position.quantity),
+                    market_price=float(market_price),
+                )
+            )
+            sold_symbols.add(symbol)
+
+        post_sell_open_positions = len(current_positions) - len(sell_orders)
+        slots_left = max(self.max_open_positions - post_sell_open_positions, 0)
+        if slots_left <= 0:
+            return [order.to_broker_dict() for order in sell_orders]
+
+        buy_signals_by_symbol: dict[str, dict[str, Any]] = {}
+        for signal in normalized:
+            if signal["action"] != "BUY":
+                continue
+            symbol = signal["symbol"]
+            market_price = price_map.get(symbol)
+            if market_price is None or float(market_price) <= 0:
+                continue
+            if symbol in sold_symbols:
+                continue
+            if not self.allow_add_to_existing and symbol in current_positions:
+                continue
+            existing = buy_signals_by_symbol.get(symbol)
+            if existing is None or (
+                float(signal["score"]) > float(existing["score"])
+                or (
+                    float(signal["score"]) == float(existing["score"])
+                    and symbol < str(existing["symbol"])
+                )
+            ):
+                buy_signals_by_symbol[symbol] = signal
+
+        buy_candidates = sorted(
+            buy_signals_by_symbol.values(),
+            key=lambda s: (-float(s["score"]), s["symbol"]),
+        )
+
+        equity = float(cash + portfolio.invested_value(price_map))
+        max_notional = float(max(equity * self.max_position_size, 0.0))
+        total_buy_cost_per_share_multiplier = (1.0 + self.slippage_rate) * (1.0 + self.commission_rate)
+
+        buy_orders: list[ExecutableOrder] = []
+        for candidate in buy_candidates:
+            if slots_left <= 0:
+                break
+            symbol = candidate["symbol"]
+            market_price = float(price_map[symbol])
+            if market_price <= 0:
+                continue
+
+            target_weight = candidate.get("target_weight")
+            if target_weight is not None:
+                desired_notional = float(equity * float(target_weight))
+            else:
+                desired_notional = float(cash / max(slots_left, 1))
+
+            notional = min(cash, max_notional, desired_notional)
+            if notional <= 0:
+                continue
+
+            effective_cost_per_share = market_price * total_buy_cost_per_share_multiplier
+            if effective_cost_per_share <= 0:
+                continue
+
+            raw_quantity = notional / effective_cost_per_share
+            quantity = float(raw_quantity if self.fractional_shares else int(raw_quantity))
+            if quantity <= 0:
+                fallback_notional = min(cash, max_notional)
+                raw_quantity = fallback_notional / effective_cost_per_share
+                quantity = float(raw_quantity if self.fractional_shares else int(raw_quantity))
+                if quantity <= 0:
+                    continue
+
+            estimated_total_cost = quantity * effective_cost_per_share
+            if estimated_total_cost > cash + 1e-12:
+                continue
+
+            buy_orders.append(
+                ExecutableOrder(
+                    symbol=symbol,
+                    side="BUY",
+                    quantity=quantity,
+                    market_price=market_price,
+                )
+            )
+            cash -= estimated_total_cost
+            slots_left -= 1
+
+        all_orders = [*sell_orders, *buy_orders]
+        return [order.to_broker_dict() for order in all_orders]

--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from src.engine.broker import Broker
 from src.engine.portfolio import Portfolio
+from src.engine.order_builder import OrderBuilder
 from src.strategy.momentum import MomentumStrategy
 from src.strategy.base import BaseStrategy, StrategySignal
 
@@ -53,6 +54,16 @@ class DailySimulator:
         self._trade_history: list[dict[str, Any]] = []
         self._signal_history: list[dict[str, Any]] = []
         self._pending_signals: dict[pd.Timestamp, list[StrategySignal]] = {}
+
+        max_open_positions = int(getattr(strategy, "max_open_positions", 1) or 1)
+        max_position_size = getattr(strategy, "max_position_size", None)
+        self.order_builder = OrderBuilder(
+            max_open_positions=max_open_positions,
+            max_position_size=max_position_size,
+            fractional_shares=self.broker.fractional_shares,
+            commission_rate=self.broker.commission_rate,
+            slippage_rate=self.broker.slippage_rate,
+        )
 
     def _ensure_runtime_state(self) -> None:
         """
@@ -184,88 +195,41 @@ class DailySimulator:
             ),
         )
 
-    def _execute_sell_signals(
+    def _execute_orders(
         self,
-        signals: list[StrategySignal],
+        orders: list[dict[str, Any]],
         execution_date: pd.Timestamp,
-        price_map: dict[str, float],
+        decision_date: pd.Timestamp,
     ) -> None:
-        for signal in signals:
-            if str(signal.action).upper() != "SELL":
+        for order in orders:
+            side = str(order.get("side", "")).upper()
+            symbol = str(order.get("symbol", "")).upper()
+            quantity = float(order.get("quantity", 0.0) or 0.0)
+            market_price = order.get("market_price")
+
+            if not symbol or side not in {"BUY", "SELL"}:
+                continue
+            if quantity <= 0 or market_price is None or float(market_price) <= 0:
                 continue
 
-            symbol = str(signal.symbol).upper()
-
-            if not self.portfolio.has_position(symbol):
-                continue
-
-            market_price = price_map.get(symbol)
-            if market_price is None:
-                continue
-
-            position = self.portfolio.get_position(symbol)
-            if position is None or position.quantity <= 0:
-                continue
-
-            result = self.broker.sell(
-                portfolio=self.portfolio,
-                symbol=symbol,
-                quantity=float(position.quantity),
-                market_price=float(market_price),
-            )
-
-            row = result.to_dict()
-            row["date"] = execution_date
-            row["decision_date"] = pd.Timestamp(signal.date)
-            row["execution_date"] = execution_date
-            self._trade_history.append(row)
-
-    def _execute_buy_signals(
-        self,
-        signals: list[StrategySignal],
-        execution_date: pd.Timestamp,
-        price_map: dict[str, float],
-    ) -> None:
-        buy_signals = [s for s in signals if str(s.action).upper() == "BUY"]
-        if not buy_signals:
-            return
-
-        equity_after_sells = self.portfolio.total_equity(price_map)
-
-        for idx, signal in enumerate(buy_signals):
-            symbol = str(signal.symbol).upper()
-
-            if self.portfolio.has_position(symbol):
-                continue
-
-            market_price = price_map.get(symbol)
-            if market_price is None:
-                continue
-
-            if signal.target_weight is not None and float(signal.target_weight) > 0:
-                cash_to_allocate = min(
-                    float(self.portfolio.cash),
-                    float(signal.target_weight) * float(equity_after_sells),
+            if side == "SELL":
+                result = self.broker.sell(
+                    portfolio=self.portfolio,
+                    symbol=symbol,
+                    quantity=quantity,
+                    market_price=float(market_price),
                 )
             else:
-                remaining = len(buy_signals) - idx
-                if remaining <= 0:
-                    break
-                cash_to_allocate = float(self.portfolio.cash) / float(remaining)
-
-            if cash_to_allocate <= 0:
-                continue
-
-            result = self.broker.buy_with_cash_amount(
-                portfolio=self.portfolio,
-                symbol=symbol,
-                cash_to_allocate=float(cash_to_allocate),
-                market_price=float(market_price),
-            )
+                result = self.broker.buy(
+                    portfolio=self.portfolio,
+                    symbol=symbol,
+                    quantity=quantity,
+                    market_price=float(market_price),
+                )
 
             row = result.to_dict()
             row["date"] = execution_date
-            row["decision_date"] = pd.Timestamp(signal.date)
+            row["decision_date"] = pd.Timestamp(decision_date)
             row["execution_date"] = execution_date
             self._trade_history.append(row)
 
@@ -309,15 +273,19 @@ class DailySimulator:
         signals = self._sort_signals(pending)
         price_map = self._day_prices(execution_date)
 
-        self._execute_sell_signals(
+        decision_date = pd.Timestamp(signals[0].date)
+
+        orders = self.order_builder.build_orders(
             signals=signals,
-            execution_date=execution_date,
+            portfolio=self.portfolio,
             price_map=price_map,
+            available_cash=float(self.portfolio.cash),
         )
-        self._execute_buy_signals(
-            signals=signals,
+
+        self._execute_orders(
+            orders=orders,
             execution_date=execution_date,
-            price_map=price_map,
+            decision_date=decision_date,
         )
 
     def _process_day(

--- a/src/engine/test_order_builder.py
+++ b/src/engine/test_order_builder.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+from src.engine.broker import Broker
+from src.engine.order_builder import OrderBuilder
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import DailySimulator
+from src.strategy.base import BaseStrategy, StrategySignal
+
+
+class EmptyStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        return []
+
+
+class OrderBuilderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.price_map = {"AAA": 10.0, "BBB": 20.0, "CCC": 5.0}
+
+    def test_buy_sell_hold_conversion_and_sell_requires_position(self) -> None:
+        portfolio = Portfolio(initial_cash=100.0)
+        portfolio.buy("AAA", quantity=2, price=10.0)
+
+        signals = [
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="AAA", action="SELL", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=0.9),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="CCC", action="HOLD", score=0.8),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="ZZZ", action="SELL", score=0.7),
+        ]
+
+        builder = OrderBuilder(max_open_positions=3)
+        orders = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual([o["side"] for o in orders], ["SELL", "BUY"])
+        self.assertEqual([o["symbol"] for o in orders], ["AAA", "BBB"])
+
+    def test_respects_available_cash(self) -> None:
+        portfolio = Portfolio(initial_cash=15.0)
+        signals = [
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="AAA", action="BUY", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=0.9),
+        ]
+
+        builder = OrderBuilder(max_open_positions=2, max_position_size=1.0, fractional_shares=False)
+        orders = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]["symbol"], "AAA")
+        self.assertEqual(orders[0]["quantity"], 1.0)
+
+    def test_respects_max_open_positions(self) -> None:
+        portfolio = Portfolio(initial_cash=100.0)
+        portfolio.buy("AAA", quantity=1, price=10.0)
+
+        signals = [
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="CCC", action="BUY", score=0.5),
+        ]
+
+        builder = OrderBuilder(max_open_positions=2)
+        orders = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]["symbol"], "BBB")
+
+    def test_respects_max_position_size(self) -> None:
+        portfolio = Portfolio(initial_cash=100.0)
+        signals = [StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="AAA", action="BUY", score=1.0)]
+
+        builder = OrderBuilder(max_open_positions=5, max_position_size=0.1, fractional_shares=False)
+        orders = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]["quantity"], 1.0)
+
+    def test_filters_duplicates_and_invalid_orders(self) -> None:
+        portfolio = Portfolio(initial_cash=100.0)
+        portfolio.buy("AAA", quantity=1, price=10.0)
+
+        signals = [
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=0.1),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="AAA", action="BUY", score=0.9),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="", action="BUY", score=0.9),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="CCC", action="UNKNOWN", score=0.9),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="ZZZ", action="BUY", score=0.9),
+        ]
+
+        builder = OrderBuilder(max_open_positions=3, fractional_shares=False)
+        orders = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]["symbol"], "BBB")
+
+    def test_deterministic_order_output(self) -> None:
+        portfolio = Portfolio(initial_cash=100.0)
+        signals = [
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="CCC", action="BUY", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="AAA", action="BUY", score=1.0),
+            StrategySignal(date=pd.Timestamp("2024-01-01"), symbol="BBB", action="BUY", score=1.0),
+        ]
+
+        builder = OrderBuilder(max_open_positions=3, fractional_shares=False)
+        first = builder.build_orders(signals=signals, portfolio=portfolio, price_map=self.price_map)
+        second = builder.build_orders(signals=list(reversed(signals)), portfolio=portfolio, price_map=self.price_map)
+
+        self.assertEqual(first, second)
+        self.assertEqual([o["symbol"] for o in first], ["AAA", "BBB", "CCC"])
+
+    def test_broker_can_consume_generated_orders(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 11.0},
+            ]
+        )
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=20.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        orders = [
+            {"symbol": "AAA", "side": "BUY", "quantity": 1.0, "market_price": 10.0},
+            {"symbol": "AAA", "side": "SELL", "quantity": 1.0, "market_price": 11.0},
+        ]
+
+        simulator._execute_orders(  # pylint: disable=protected-access
+            orders=orders,
+            execution_date=pd.Timestamp("2024-01-02"),
+            decision_date=pd.Timestamp("2024-01-01"),
+        )
+
+        self.assertEqual(len(simulator._trade_history), 2)  # pylint: disable=protected-access
+        self.assertAlmostEqual(simulator.portfolio.cash, 21.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #20

## What changed
- added an order-building/allocation layer
- converted strategy buy/sell/hold signals into executable order lists
- enforced available cash, max open positions, and position sizing constraints
- filtered duplicate and invalid orders safely
- ensured generated orders are broker-consumable without manual fixes

## Why
This PR adds the missing layer between strategy outputs and broker execution so signals can be transformed into deterministic and valid orders under portfolio constraints.

## Notes
Order generation is deterministic and designed to stay reusable for future strategies.