### PR TITLE
feat: export structured trade log

### DIFF
--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -22,6 +22,28 @@ from src.strategy.base import BaseStrategy, StrategySignal
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PROCESSED_DATA_DIR = REPO_ROOT / "data" / "processed"
 FEATURES_FILE = PROCESSED_DATA_DIR / "market_features.parquet"
+BACKTEST_OUTPUTS_DIR = REPO_ROOT / "outputs" / "backtests"
+TRADE_LOG_FILENAME = "trade_log.csv"
+
+TRADE_LOG_COLUMNS = [
+    "order_id",
+    "decision_date",
+    "execution_date",
+    "symbol",
+    "side",
+    "quantity",
+    "price",
+    "fees",
+    "slippage",
+    "execution_status",
+    "reason",
+    "cash_before",
+    "cash_after",
+    "decision_price",
+    "execution_price",
+    "strategy_name",
+    "created_at",
+]
 
 
 class DailySimulator:
@@ -52,8 +74,10 @@ class DailySimulator:
         self._portfolio_history: list[dict[str, Any]] = []
         self._positions_history: list[dict[str, Any]] = []
         self._trade_history: list[dict[str, Any]] = []
+        self._trade_log_history: list[dict[str, Any]] = []
         self._signal_history: list[dict[str, Any]] = []
         self._pending_signals: dict[pd.Timestamp, list[StrategySignal]] = {}
+        self._order_sequence: int = 0
 
         max_open_positions = int(getattr(strategy, "max_open_positions", 1) or 1)
         max_position_size = getattr(strategy, "max_position_size", None)
@@ -184,6 +208,20 @@ class DailySimulator:
         )
 
     @staticmethod
+    def _format_datetime(value: Any) -> str | None:
+        if value is None or pd.isna(value):
+            return None
+        return pd.Timestamp(value).isoformat()
+
+    def _next_order_id(self) -> str:
+        self._order_sequence += 1
+        return f"ORD-{self._order_sequence:08d}"
+
+    def _record_trade_log(self, row: dict[str, Any]) -> None:
+        normalized = {col: row.get(col) for col in TRADE_LOG_COLUMNS}
+        self._trade_log_history.append(normalized)
+
+    @staticmethod
     def _sort_signals(signals: list[StrategySignal]) -> list[StrategySignal]:
         action_priority = {"SELL": 0, "BUY": 1, "HOLD": 2}
         return sorted(
@@ -206,10 +244,53 @@ class DailySimulator:
             symbol = str(order.get("symbol", "")).upper()
             quantity = float(order.get("quantity", 0.0) or 0.0)
             market_price = order.get("market_price")
+            order_id = self._next_order_id()
 
             if not symbol or side not in {"BUY", "SELL"}:
+                self._record_trade_log(
+                    {
+                        "order_id": order_id,
+                        "decision_date": self._format_datetime(decision_date),
+                        "execution_date": self._format_datetime(execution_date),
+                        "symbol": symbol,
+                        "side": side,
+                        "quantity": quantity,
+                        "price": None,
+                        "fees": 0.0,
+                        "slippage": 0.0,
+                        "execution_status": "SKIPPED_INVALID_ORDER",
+                        "reason": "Order has invalid side or symbol.",
+                        "cash_before": float(self.portfolio.cash),
+                        "cash_after": float(self.portfolio.cash),
+                        "decision_price": market_price,
+                        "execution_price": None,
+                        "strategy_name": self.strategy.__class__.__name__,
+                        "created_at": self._format_datetime(execution_date),
+                    }
+                )
                 continue
             if quantity <= 0 or market_price is None or float(market_price) <= 0:
+                self._record_trade_log(
+                    {
+                        "order_id": order_id,
+                        "decision_date": self._format_datetime(decision_date),
+                        "execution_date": self._format_datetime(execution_date),
+                        "symbol": symbol,
+                        "side": side,
+                        "quantity": quantity,
+                        "price": None,
+                        "fees": 0.0,
+                        "slippage": 0.0,
+                        "execution_status": "SKIPPED_INVALID_ORDER",
+                        "reason": "Order has invalid quantity or market price.",
+                        "cash_before": float(self.portfolio.cash),
+                        "cash_after": float(self.portfolio.cash),
+                        "decision_price": market_price,
+                        "execution_price": None,
+                        "strategy_name": self.strategy.__class__.__name__,
+                        "created_at": self._format_datetime(execution_date),
+                    }
+                )
                 continue
 
             if side == "SELL":
@@ -232,6 +313,29 @@ class DailySimulator:
             row["decision_date"] = pd.Timestamp(decision_date)
             row["execution_date"] = execution_date
             self._trade_history.append(row)
+            self._record_trade_log(
+                {
+                    "order_id": order_id,
+                    "decision_date": self._format_datetime(decision_date),
+                    "execution_date": self._format_datetime(execution_date),
+                    "symbol": symbol,
+                    "side": side,
+                    "quantity": float(row.get("requested_quantity", 0.0) or 0.0),
+                    "price": row.get("execution_price")
+                    if row.get("execution_price") is not None
+                    else row.get("requested_price"),
+                    "fees": float(row.get("fee", 0.0) or 0.0),
+                    "slippage": float(row.get("slippage_cost", 0.0) or 0.0),
+                    "execution_status": "EXECUTED" if bool(row.get("success")) else "REJECTED",
+                    "reason": row.get("message", ""),
+                    "cash_before": float(row.get("cash_before", 0.0) or 0.0),
+                    "cash_after": float(row.get("cash_after", 0.0) or 0.0),
+                    "decision_price": row.get("requested_price"),
+                    "execution_price": row.get("execution_price"),
+                    "strategy_name": self.strategy.__class__.__name__,
+                    "created_at": self._format_datetime(execution_date),
+                }
+            )
 
     @staticmethod
     def _next_trading_date_map(
@@ -256,6 +360,31 @@ class DailySimulator:
                 scheduled_execution_date=None,
                 schedule_status="NO_NEXT_TRADING_SESSION",
             )
+            for signal in signals:
+                side = str(signal.action).upper()
+                if side not in {"BUY", "SELL"}:
+                    continue
+                self._record_trade_log(
+                    {
+                        "order_id": self._next_order_id(),
+                        "decision_date": self._format_datetime(signal.date),
+                        "execution_date": None,
+                        "symbol": str(signal.symbol).upper(),
+                        "side": side,
+                        "quantity": None,
+                        "price": None,
+                        "fees": 0.0,
+                        "slippage": 0.0,
+                        "execution_status": "SKIPPED_NO_NEXT_SESSION",
+                        "reason": str(signal.reason_code or "No next trading session available."),
+                        "cash_before": float(self.portfolio.cash),
+                        "cash_after": float(self.portfolio.cash),
+                        "decision_price": None,
+                        "execution_price": None,
+                        "strategy_name": self.strategy.__class__.__name__,
+                        "created_at": self._format_datetime(signal.date),
+                    }
+                )
             return
 
         self._record_signals(
@@ -324,7 +453,9 @@ class DailySimulator:
         self._portfolio_history.clear()
         self._positions_history.clear()
         self._trade_history.clear()
+        self._trade_log_history.clear()
         self._signal_history.clear()
+        self._order_sequence = 0
 
         trading_dates = self._selected_trading_dates(
             start_date=start_date,
@@ -345,6 +476,7 @@ class DailySimulator:
         positions_history = pd.DataFrame(self._positions_history)
         trade_history = pd.DataFrame(self._trade_history)
         signal_history = pd.DataFrame(self._signal_history)
+        trade_log = pd.DataFrame(self._trade_log_history, columns=TRADE_LOG_COLUMNS)
 
         if not portfolio_history.empty:
             portfolio_history = portfolio_history.sort_values("date").reset_index(drop=True)
@@ -364,11 +496,22 @@ class DailySimulator:
                 ["date", "symbol", "action"]
             ).reset_index(drop=True)
 
+        if not trade_log.empty:
+            trade_log = trade_log.sort_values(
+                ["decision_date", "symbol", "side", "order_id"]
+            ).reset_index(drop=True)
+
+        BACKTEST_OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
+        trade_log_path = BACKTEST_OUTPUTS_DIR / TRADE_LOG_FILENAME
+        trade_log.to_csv(trade_log_path, index=False)
+
         return {
             "portfolio_history": portfolio_history,
             "positions_history": positions_history,
             "trade_history": trade_history,
             "signal_history": signal_history,
+            "trade_log": trade_log,
+            "trade_log_path": trade_log_path,
         }
 
 

--- a/src/engine/test_trade_log_export.py
+++ b/src/engine/test_trade_log_export.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+import src.engine.simulator as simulator_module
+from src.engine.broker import Broker
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import DailySimulator, TRADE_LOG_COLUMNS
+from src.strategy.base import BaseStrategy, StrategySignal
+
+
+class MixedSignalStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        d = pd.to_datetime(decision_date)
+        if d == pd.Timestamp("2024-01-01"):
+            return [
+                StrategySignal(date=d, symbol="AAA", action="BUY", score=1.0, reason_code="BUY_ENTRY"),
+            ]
+        if d == pd.Timestamp("2024-01-03"):
+            return [
+                StrategySignal(date=d, symbol="AAA", action="SELL", score=1.0, reason_code="SELL_EXIT"),
+            ]
+        return []
+
+
+class EmptyStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        return []
+
+
+class TradeLogExportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_output_dir = simulator_module.BACKTEST_OUTPUTS_DIR
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        simulator_module.BACKTEST_OUTPUTS_DIR = Path(self._tmp_dir.name) / "outputs" / "backtests"
+
+    def tearDown(self) -> None:
+        simulator_module.BACKTEST_OUTPUTS_DIR = self._original_output_dir
+        self._tmp_dir.cleanup()
+
+    def test_logs_executed_and_skipped_orders_and_writes_csv(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 11.0},
+                {"date": "2024-01-03", "symbol": "AAA", "adj_close": 12.0},
+            ]
+        )
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=MixedSignalStrategy(),
+            portfolio=Portfolio(initial_cash=100.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run()
+
+        trade_log = results["trade_log"]
+        self.assertIn("EXECUTED", set(trade_log["execution_status"]))
+        self.assertIn("SKIPPED_NO_NEXT_SESSION", set(trade_log["execution_status"]))
+
+        executed = trade_log.loc[trade_log["execution_status"] == "EXECUTED"].iloc[0]
+        self.assertEqual(executed["symbol"], "AAA")
+        self.assertEqual(executed["side"], "BUY")
+        self.assertEqual(executed["decision_date"], "2024-01-01T00:00:00")
+        self.assertEqual(executed["execution_date"], "2024-01-02T00:00:00")
+
+        exported_path = results["trade_log_path"]
+        self.assertIn(str(Path("outputs") / "backtests"), str(exported_path))
+        self.assertTrue(exported_path.exists())
+
+        loaded = pd.read_csv(exported_path)
+        self.assertGreaterEqual(len(loaded), 2)
+        self.assertEqual(list(loaded.columns), TRADE_LOG_COLUMNS)
+
+    def test_rejected_order_attempt_is_logged(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 10.0},
+            ]
+        )
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=0.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        simulator._execute_orders(  # pylint: disable=protected-access
+            orders=[{"symbol": "AAA", "side": "BUY", "quantity": 1.0, "market_price": 10.0}],
+            execution_date=pd.Timestamp("2024-01-02"),
+            decision_date=pd.Timestamp("2024-01-01"),
+        )
+
+        log = pd.DataFrame(simulator._trade_log_history)  # pylint: disable=protected-access
+        self.assertEqual(log.iloc[0]["execution_status"], "REJECTED")
+        self.assertIn("Insufficient cash", str(log.iloc[0]["reason"]))
+
+    def test_empty_run_exports_machine_readable_headers(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 10.0},
+            ]
+        )
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=100.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run()
+        trade_log = results["trade_log"]
+
+        self.assertTrue(trade_log.empty)
+        exported_path = results["trade_log_path"]
+        loaded = pd.read_csv(exported_path)
+        self.assertTrue(loaded.empty)
+        self.assertEqual(list(loaded.columns), TRADE_LOG_COLUMNS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #21

## What changed
- added a structured trade log export flow for backtest runs
- recorded decision date and execution date for each order attempt
- logged symbol, side, quantity, price, fees, slippage, and execution status
- saved machine-readable trade logs under `outputs/backtests/`
- made the exported ledger reusable for later analysis and UI layers

## Why
This PR adds a consistent trade ledger output so every executed or rejected order can be traced and reused outside the simulator.

## Notes
The export format is designed to stay simple, structured, and easy to load in later analytics or UI components.