### PR TITLE
feat(engine): save daily position snapshots

### DIFF
--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -25,6 +25,7 @@ FEATURES_FILE = PROCESSED_DATA_DIR / "market_features.parquet"
 BACKTEST_OUTPUTS_DIR = REPO_ROOT / "outputs" / "backtests"
 TRADE_LOG_FILENAME = "trade_log.csv"
 PORTFOLIO_SNAPSHOT_FILENAME = "daily_portfolio_snapshots.csv"
+POSITION_SNAPSHOT_FILENAME = "daily_position_snapshots.csv"
 
 TRADE_LOG_COLUMNS = [
     "order_id",
@@ -54,6 +55,18 @@ PORTFOLIO_SNAPSHOT_COLUMNS = [
     "realized_pnl",
     "unrealized_pnl",
     "open_positions",
+]
+
+POSITION_SNAPSHOT_COLUMNS = [
+    "date",
+    "symbol",
+    "quantity",
+    "average_cost",
+    "latest_price",
+    "market_value",
+    "unrealized_pnl",
+    "position_weight",
+    "portfolio_total_equity",
 ]
 
 
@@ -86,6 +99,55 @@ class PortfolioSnapshotWriter:
             snapshots[column] = pd.to_numeric(snapshots[column], errors="coerce")
 
         snapshots = snapshots.reset_index(drop=True)
+        return snapshots
+
+    @staticmethod
+    def write_csv(snapshots: pd.DataFrame, output_path: Path) -> Path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshots.to_csv(output_path, index=False)
+        return output_path
+
+
+class PositionSnapshotWriter:
+    @staticmethod
+    def from_positions_history(
+        positions_history: pd.DataFrame,
+        portfolio_snapshots: pd.DataFrame,
+    ) -> pd.DataFrame:
+        if positions_history.empty:
+            return pd.DataFrame(columns=POSITION_SNAPSHOT_COLUMNS)
+
+        snapshots = positions_history.copy()
+        snapshots["date"] = pd.to_datetime(snapshots["date"]).dt.normalize()
+        snapshots = snapshots.rename(
+            columns={
+                "avg_cost": "average_cost",
+                "last_price": "latest_price",
+            }
+        )
+
+        equity = portfolio_snapshots[["date", "total_equity"]].rename(
+            columns={"total_equity": "portfolio_total_equity"}
+        )
+        equity["date"] = pd.to_datetime(equity["date"]).dt.normalize()
+
+        snapshots = snapshots.merge(equity, on="date", how="left")
+        snapshots = snapshots.sort_values(["date", "symbol"]).reset_index(drop=True)
+
+        for column in [
+            "quantity",
+            "average_cost",
+            "latest_price",
+            "market_value",
+            "unrealized_pnl",
+            "portfolio_total_equity",
+        ]:
+            snapshots[column] = pd.to_numeric(snapshots[column], errors="coerce")
+
+        snapshots["position_weight"] = snapshots["market_value"] / snapshots["portfolio_total_equity"]
+        snapshots.loc[snapshots["portfolio_total_equity"] == 0.0, "position_weight"] = 0.0
+
+        snapshots = snapshots[POSITION_SNAPSHOT_COLUMNS]
         return snapshots
 
     @staticmethod
@@ -531,6 +593,10 @@ class DailySimulator:
             portfolio_history = portfolio_history.sort_values("date").reset_index(drop=True)
 
         portfolio_snapshots = PortfolioSnapshotWriter.from_portfolio_history(portfolio_history)
+        position_snapshots = PositionSnapshotWriter.from_positions_history(
+            positions_history=positions_history,
+            portfolio_snapshots=portfolio_snapshots,
+        )
 
         if not positions_history.empty:
             positions_history = positions_history.sort_values(
@@ -555,18 +621,22 @@ class DailySimulator:
         BACKTEST_OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
         trade_log_path = BACKTEST_OUTPUTS_DIR / TRADE_LOG_FILENAME
         portfolio_snapshots_path = BACKTEST_OUTPUTS_DIR / PORTFOLIO_SNAPSHOT_FILENAME
+        position_snapshots_path = BACKTEST_OUTPUTS_DIR / POSITION_SNAPSHOT_FILENAME
         trade_log.to_csv(trade_log_path, index=False)
         PortfolioSnapshotWriter.write_csv(portfolio_snapshots, portfolio_snapshots_path)
+        PositionSnapshotWriter.write_csv(position_snapshots, position_snapshots_path)
 
         return {
             "portfolio_history": portfolio_history,
             "portfolio_snapshots": portfolio_snapshots,
+            "position_snapshots": position_snapshots,
             "positions_history": positions_history,
             "trade_history": trade_history,
             "signal_history": signal_history,
             "trade_log": trade_log,
             "trade_log_path": trade_log_path,
             "portfolio_snapshots_path": portfolio_snapshots_path,
+            "position_snapshots_path": position_snapshots_path,
         }
 
 

--- a/src/engine/test_position_snapshot_export.py
+++ b/src/engine/test_position_snapshot_export.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+import src.engine.simulator as simulator_module
+from src.engine.broker import Broker
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import DailySimulator, POSITION_SNAPSHOT_COLUMNS
+from src.strategy.base import BaseStrategy, StrategySignal
+
+
+class BuyThenSellStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        d = pd.to_datetime(decision_date)
+        if d == pd.Timestamp("2024-01-01"):
+            return [
+                StrategySignal(date=d, symbol="AAA", action="BUY", score=1.0, reason_code="ENTRY"),
+            ]
+        if d == pd.Timestamp("2024-01-03") and portfolio.has_position("AAA"):
+            return [
+                StrategySignal(date=d, symbol="AAA", action="SELL", score=1.0, reason_code="EXIT"),
+            ]
+        return []
+
+
+class BuyOnlyStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        d = pd.to_datetime(decision_date)
+        if d == pd.Timestamp("2024-01-01"):
+            return [
+                StrategySignal(date=d, symbol="AAA", action="BUY", score=1.0, reason_code="ENTRY"),
+            ]
+        return []
+
+
+class PositionSnapshotExportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_output_dir = simulator_module.BACKTEST_OUTPUTS_DIR
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        simulator_module.BACKTEST_OUTPUTS_DIR = Path(self._tmp_dir.name) / "outputs" / "backtests"
+
+    def tearDown(self) -> None:
+        simulator_module.BACKTEST_OUTPUTS_DIR = self._original_output_dir
+        self._tmp_dir.cleanup()
+
+    def test_position_snapshots_export_daily_history_with_consistent_valuation(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 11.0},
+                {"date": "2024-01-03", "symbol": "AAA", "adj_close": 12.0},
+                {"date": "2024-01-04", "symbol": "AAA", "adj_close": 13.0},
+                {"date": "2024-01-05", "symbol": "AAA", "adj_close": 14.0},
+            ]
+        )
+
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=BuyThenSellStrategy(),
+            portfolio=Portfolio(initial_cash=100.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run()
+        position_snapshots = results["position_snapshots"]
+        portfolio_snapshots = results["portfolio_snapshots"]
+
+        self.assertEqual(list(position_snapshots.columns), POSITION_SNAPSHOT_COLUMNS)
+        self.assertTrue(position_snapshots[["date", "symbol"]].equals(
+            position_snapshots.sort_values(["date", "symbol"])[["date", "symbol"]].reset_index(drop=True)
+        ))
+
+        active_dates = set(pd.to_datetime(position_snapshots["date"]).dt.normalize())
+        self.assertEqual(
+            active_dates,
+            {
+                pd.Timestamp("2024-01-02"),
+                pd.Timestamp("2024-01-03"),
+            },
+        )
+
+        self.assertTrue((position_snapshots["market_value"] == position_snapshots["quantity"] * position_snapshots["latest_price"]).all())
+        self.assertTrue((position_snapshots["unrealized_pnl"] == position_snapshots["market_value"] - (position_snapshots["quantity"] * position_snapshots["average_cost"])).all())
+
+        invested_by_day = position_snapshots.groupby("date")["market_value"].sum().sort_index()
+        invested_reference = (
+            portfolio_snapshots.set_index("date").loc[invested_by_day.index, "invested_value"].sort_index()
+        )
+        self.assertTrue((invested_by_day - invested_reference).abs().lt(1e-9).all())
+
+        weight_sum_by_day = position_snapshots.groupby("date")["position_weight"].sum().sort_index()
+        invested_weight_reference = (
+            portfolio_snapshots.set_index("date").loc[weight_sum_by_day.index, "invested_value"]
+            / portfolio_snapshots.set_index("date").loc[weight_sum_by_day.index, "total_equity"]
+        ).sort_index()
+        self.assertTrue((weight_sum_by_day - invested_weight_reference).abs().lt(1e-9).all())
+
+        for day in [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-04"), pd.Timestamp("2024-01-05")]:
+            self.assertFalse((pd.to_datetime(position_snapshots["date"]).dt.normalize() == day).any())
+
+        exported_path = results["position_snapshots_path"]
+        self.assertTrue(exported_path.exists())
+        loaded = pd.read_csv(exported_path, parse_dates=["date"])
+        self.assertEqual(list(loaded.columns), POSITION_SNAPSHOT_COLUMNS)
+        self.assertEqual(len(loaded), len(position_snapshots))
+
+    def test_missing_latest_price_for_open_position_is_handled_cleanly(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-01", "symbol": "AAA", "adj_close": 10.0},
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 11.0},
+                {"date": "2024-01-03", "symbol": "BBB", "adj_close": 20.0},
+                {"date": "2024-01-04", "symbol": "AAA", "adj_close": 13.0},
+            ]
+        )
+
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=BuyOnlyStrategy(),
+            portfolio=Portfolio(initial_cash=100.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run()
+        snapshots = results["position_snapshots"]
+
+        jan03_row = snapshots.loc[pd.to_datetime(snapshots["date"]).dt.normalize() == pd.Timestamp("2024-01-03")]
+        self.assertEqual(len(jan03_row), 1)
+        self.assertTrue(pd.isna(jan03_row.iloc[0]["latest_price"]))
+        self.assertTrue(pd.isna(jan03_row.iloc[0]["market_value"]))
+        self.assertTrue(pd.isna(jan03_row.iloc[0]["unrealized_pnl"]))
+        self.assertTrue(pd.isna(jan03_row.iloc[0]["position_weight"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #23

## What changed
- added a daily position snapshot export to the backtest flow
- recorded symbol, quantity, average cost, latest price, market value, unrealized PnL, and position weight
- tracked open holdings across trading days in a machine-readable format
- handled zero-position days cleanly
- kept position snapshots consistent with portfolio-level snapshots

## Why
This PR adds a structured daily position history so holdings can be tracked over time and reused later for reporting and UI work.

## Notes
The export is designed to stay simple, consistent, and aligned with daily portfolio snapshot outputs.