### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kaany43/autonomous-paper-trader/security/code-scanning/1](https://github.com/kaany43/autonomous-paper-trader/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow, granting only the minimal scopes required. Since this CI job only checks out repository contents and runs local Python commands, it only needs read access to repository contents (and no other scopes). The recommended minimal block is `permissions: contents: read` at the workflow or job level.

The best way to fix this specific workflow without changing functionality is to add a root-level `permissions` section just under the `name: CI` line. This will apply to all jobs (here, the single `ci` job) that do not define their own permissions. Concretely, in `.github/workflows/ci.yml`, between lines 1 and 3, insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed because this is purely GitHub Actions YAML configuration. The rest of the workflow (triggers, steps, and commands) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
