### PR TITLE
Add benchmark equity comparison export to backtests

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -30,7 +30,7 @@ strategy:
   top_k: 2
 
 benchmark:
-  symbol: "QQQ"
+  benchmark_symbol: "QQQ"
 
 output:
   save_trades_csv: true

--- a/src/data/downloader.py
+++ b/src/data/downloader.py
@@ -54,8 +54,12 @@ def load_universe() -> list[str]:
 
 def get_all_symbols(settings: dict[str, Any], universe_symbols: list[str]) -> list[str]:
     """Return universe symbols plus benchmark if it is not already included."""
-    benchmark_symbol = (
-        settings.get("benchmark", {}).get("symbol", "") or ""
+    benchmark_cfg = settings.get("benchmark", {})
+    benchmark_symbol = str(
+        benchmark_cfg.get("benchmark_symbol")
+        or benchmark_cfg.get("symbol")
+        or settings.get("benchmark_symbol")
+        or ""
     ).strip().upper()
 
     symbols = list(universe_symbols)

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -68,15 +68,26 @@ def get_target_symbols() -> list[str]:
     settings = load_settings()
     universe_symbols = load_universe()
 
-    benchmark_symbol = (
-        settings.get("benchmark", {}).get("symbol", "") or ""
-    ).strip().upper()
+    benchmark_symbol = get_benchmark_symbol(settings)
 
     symbols = list(universe_symbols)
     if benchmark_symbol and benchmark_symbol not in symbols:
         symbols.append(benchmark_symbol)
 
     return symbols
+
+
+def get_benchmark_symbol(settings: dict[str, Any] | None = None) -> str:
+    """Return normalized benchmark symbol from settings."""
+    resolved_settings = settings or load_settings()
+    benchmark_cfg = resolved_settings.get("benchmark", {})
+    raw_symbol = (
+        benchmark_cfg.get("benchmark_symbol")
+        or benchmark_cfg.get("symbol")
+        or resolved_settings.get("benchmark_symbol")
+        or ""
+    )
+    return str(raw_symbol).strip().upper()
 
 
 def validate_schema(df: pd.DataFrame, symbol: str) -> None:

--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -26,6 +26,7 @@ BACKTEST_OUTPUTS_DIR = REPO_ROOT / "outputs" / "backtests"
 TRADE_LOG_FILENAME = "trade_log.csv"
 PORTFOLIO_SNAPSHOT_FILENAME = "daily_portfolio_snapshots.csv"
 POSITION_SNAPSHOT_FILENAME = "daily_position_snapshots.csv"
+BENCHMARK_EQUITY_FILENAME = "benchmark_equity_curve.csv"
 
 TRADE_LOG_COLUMNS = [
     "order_id",
@@ -67,6 +68,15 @@ POSITION_SNAPSHOT_COLUMNS = [
     "unrealized_pnl",
     "position_weight",
     "portfolio_total_equity",
+]
+
+BENCHMARK_EQUITY_COLUMNS = [
+    "date",
+    "benchmark_symbol",
+    "benchmark_price",
+    "benchmark_return",
+    "benchmark_equity",
+    "cumulative_return",
 ]
 
 
@@ -154,6 +164,82 @@ class PositionSnapshotWriter:
     def write_csv(snapshots: pd.DataFrame, output_path: Path) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         snapshots.to_csv(output_path, index=False)
+        return output_path
+
+
+class BenchmarkComparator:
+    @staticmethod
+    def build_benchmark_curve(
+        market_data: pd.DataFrame,
+        portfolio_snapshots: pd.DataFrame,
+        benchmark_symbol: str,
+        initial_capital: float,
+        price_column: str,
+    ) -> pd.DataFrame:
+        canonical_dates = pd.DataFrame({
+            "date": pd.to_datetime(portfolio_snapshots.get("date", pd.Series(dtype="datetime64[ns]"))).dt.normalize()
+        })
+        canonical_dates = canonical_dates.dropna().drop_duplicates(subset=["date"]).sort_values("date")
+
+        if canonical_dates.empty:
+            return pd.DataFrame(columns=BENCHMARK_EQUITY_COLUMNS)
+
+        symbol = str(benchmark_symbol or "").strip().upper()
+        if not symbol:
+            curve = canonical_dates.copy()
+            curve["benchmark_symbol"] = ""
+            curve["benchmark_price"] = pd.NA
+            curve["benchmark_return"] = 0.0
+            curve["benchmark_equity"] = float(initial_capital)
+            curve["cumulative_return"] = 0.0
+            return curve[BENCHMARK_EQUITY_COLUMNS]
+
+        benchmark_prices = market_data.loc[
+            market_data["symbol"].astype(str).str.upper().str.strip() == symbol,
+            ["date", price_column],
+        ].copy()
+
+        if benchmark_prices.empty:
+            curve = canonical_dates.copy()
+            curve["benchmark_symbol"] = symbol
+            curve["benchmark_price"] = pd.NA
+            curve["benchmark_return"] = 0.0
+            curve["benchmark_equity"] = float(initial_capital)
+            curve["cumulative_return"] = 0.0
+            return curve[BENCHMARK_EQUITY_COLUMNS]
+
+        benchmark_prices["date"] = pd.to_datetime(benchmark_prices["date"]).dt.normalize()
+        benchmark_prices[price_column] = pd.to_numeric(benchmark_prices[price_column], errors="coerce")
+        benchmark_prices = benchmark_prices.drop_duplicates(subset=["date"], keep="last")
+        benchmark_prices = benchmark_prices.rename(columns={price_column: "benchmark_price"})
+
+        curve = canonical_dates.merge(benchmark_prices, on="date", how="left").sort_values("date")
+        curve["benchmark_symbol"] = symbol
+        curve["benchmark_price"] = curve["benchmark_price"].ffill().bfill()
+
+        if curve["benchmark_price"].isna().all():
+            curve["benchmark_return"] = 0.0
+            curve["benchmark_equity"] = float(initial_capital)
+            curve["cumulative_return"] = 0.0
+            return curve[BENCHMARK_EQUITY_COLUMNS]
+
+        curve["benchmark_return"] = curve["benchmark_price"].pct_change().fillna(0.0)
+        curve["benchmark_return"] = curve["benchmark_return"].replace([pd.NA, float("inf"), float("-inf")], 0.0).fillna(0.0)
+
+        starting_capital = float(initial_capital)
+        curve["benchmark_equity"] = starting_capital * (1.0 + curve["benchmark_return"]).cumprod()
+
+        if starting_capital == 0.0:
+            curve["cumulative_return"] = 0.0
+        else:
+            curve["cumulative_return"] = curve["benchmark_equity"] / starting_capital - 1.0
+
+        return curve[BENCHMARK_EQUITY_COLUMNS]
+
+    @staticmethod
+    def write_csv(curve: pd.DataFrame, output_path: Path) -> Path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        curve.to_csv(output_path, index=False)
         return output_path
 
 
@@ -560,6 +646,8 @@ class DailySimulator:
         self,
         start_date: str | pd.Timestamp | None = None,
         end_date: str | pd.Timestamp | None = None,
+        benchmark_symbol: str = "",
+        benchmark_output_filename: str = BENCHMARK_EQUITY_FILENAME,
     ) -> dict[str, pd.DataFrame]:
         self._portfolio_history.clear()
         self._positions_history.clear()
@@ -618,13 +706,23 @@ class DailySimulator:
                 ["decision_date", "symbol", "side", "order_id"]
             ).reset_index(drop=True)
 
+        benchmark_curve = BenchmarkComparator.build_benchmark_curve(
+            market_data=self.market_data,
+            portfolio_snapshots=portfolio_snapshots,
+            benchmark_symbol=benchmark_symbol,
+            initial_capital=float(getattr(self.portfolio, "initial_cash", 0.0)),
+            price_column=self.price_column,
+        )
+
         BACKTEST_OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
         trade_log_path = BACKTEST_OUTPUTS_DIR / TRADE_LOG_FILENAME
         portfolio_snapshots_path = BACKTEST_OUTPUTS_DIR / PORTFOLIO_SNAPSHOT_FILENAME
         position_snapshots_path = BACKTEST_OUTPUTS_DIR / POSITION_SNAPSHOT_FILENAME
+        benchmark_curve_path = BACKTEST_OUTPUTS_DIR / str(benchmark_output_filename or BENCHMARK_EQUITY_FILENAME)
         trade_log.to_csv(trade_log_path, index=False)
         PortfolioSnapshotWriter.write_csv(portfolio_snapshots, portfolio_snapshots_path)
         PositionSnapshotWriter.write_csv(position_snapshots, position_snapshots_path)
+        BenchmarkComparator.write_csv(benchmark_curve, benchmark_curve_path)
 
         return {
             "portfolio_history": portfolio_history,
@@ -634,9 +732,11 @@ class DailySimulator:
             "trade_history": trade_history,
             "signal_history": signal_history,
             "trade_log": trade_log,
+            "benchmark_curve": benchmark_curve,
             "trade_log_path": trade_log_path,
             "portfolio_snapshots_path": portfolio_snapshots_path,
             "position_snapshots_path": position_snapshots_path,
+            "benchmark_curve_path": benchmark_curve_path,
         }
 
 

--- a/src/engine/test_benchmark_export.py
+++ b/src/engine/test_benchmark_export.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+import src.engine.simulator as simulator_module
+from src.data.loader import get_benchmark_symbol
+from src.engine.broker import Broker
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import BENCHMARK_EQUITY_COLUMNS, DailySimulator
+from src.strategy.base import BaseStrategy
+
+
+class EmptyStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        return []
+
+
+class BenchmarkExportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_output_dir = simulator_module.BACKTEST_OUTPUTS_DIR
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        simulator_module.BACKTEST_OUTPUTS_DIR = Path(self._tmp_dir.name) / "outputs" / "backtests"
+
+    def tearDown(self) -> None:
+        simulator_module.BACKTEST_OUTPUTS_DIR = self._original_output_dir
+        self._tmp_dir.cleanup()
+
+    def test_reads_benchmark_symbol_from_new_config_field(self) -> None:
+        settings = {"benchmark": {"benchmark_symbol": "spy"}}
+        self.assertEqual(get_benchmark_symbol(settings), "SPY")
+
+    def test_builds_aligned_normalized_benchmark_curve_and_writes_csv(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 50.0},
+                {"date": "2024-01-03", "symbol": "AAA", "adj_close": 51.0},
+                {"date": "2024-01-04", "symbol": "AAA", "adj_close": 52.0},
+                {"date": "2024-01-05", "symbol": "AAA", "adj_close": 53.0},
+                {"date": "2024-01-02", "symbol": "QQQ", "adj_close": 100.0},
+                {"date": "2024-01-04", "symbol": "QQQ", "adj_close": 110.0},
+                {"date": "2024-01-05", "symbol": "QQQ", "adj_close": 121.0},
+            ]
+        )
+
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=100000.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run(
+            start_date="2024-01-02",
+            end_date="2024-01-05",
+            benchmark_symbol="QQQ",
+        )
+
+        benchmark_curve = results["benchmark_curve"]
+        self.assertEqual(list(benchmark_curve.columns), BENCHMARK_EQUITY_COLUMNS)
+        self.assertEqual(len(benchmark_curve), 4)
+
+        dates = pd.to_datetime(benchmark_curve["date"])
+        self.assertEqual(dates.min(), pd.Timestamp("2024-01-02"))
+        self.assertEqual(dates.max(), pd.Timestamp("2024-01-05"))
+
+        self.assertEqual(float(benchmark_curve.iloc[0]["benchmark_equity"]), 100000.0)
+        self.assertEqual(float(benchmark_curve.iloc[1]["benchmark_return"]), 0.0)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[2]["benchmark_return"]), 0.10, places=8)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[3]["benchmark_equity"]), 121000.0, places=6)
+
+        self.assertEqual(
+            list(pd.to_datetime(benchmark_curve["date"])),
+            list(pd.to_datetime(results["portfolio_snapshots"]["date"])),
+        )
+
+        output_path = results["benchmark_curve_path"]
+        self.assertTrue(output_path.exists())
+        loaded = pd.read_csv(output_path)
+        self.assertEqual(list(loaded.columns), BENCHMARK_EQUITY_COLUMNS)
+        self.assertEqual(len(loaded), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #24

## What changed
- added benchmark symbol support to config
- computed benchmark returns over the same backtest window
- normalized benchmark performance to the same starting capital
- saved a benchmark equity curve alongside simulation outputs
- aligned benchmark dates with portfolio dates for direct comparison

## Why
This PR adds a benchmark comparison layer so strategy performance can be evaluated against a reference asset over the same simulation period.

## Notes
The benchmark output is designed to stay simple, machine-readable, and ready for future charts and reports.