### PR TITLE
Feat/run artifacts manifest

### DIFF
--- a/src/engine/run_artifacts.py
+++ b/src/engine/run_artifacts.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+MANIFEST_FILENAME = "manifest.json"
+CONFIG_FILENAME = "config.json"
+
+
+class RunArtifactManager:
+    def __init__(
+        self,
+        base_output_dir: Path,
+        strategy_name: str = "",
+        benchmark_symbol: str = "",
+        start_date: str = "",
+        end_date: str = "",
+    ) -> None:
+        self.base_output_dir = Path(base_output_dir)
+        self.base_output_dir.mkdir(parents=True, exist_ok=True)
+
+        self.strategy_name = str(strategy_name or "")
+        self.benchmark_symbol = str(benchmark_symbol or "")
+        self.start_date = str(start_date or "")
+        self.end_date = str(end_date or "")
+
+        self.run_id = self._build_unique_run_id()
+        self.output_dir = self.base_output_dir / self.run_id
+        self.output_dir.mkdir(parents=True, exist_ok=False)
+
+        self.created_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        self._artifacts: dict[str, str] = {}
+
+    def _build_unique_run_id(self) -> str:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_id = timestamp
+        suffix = 0
+        while (self.base_output_dir / run_id).exists():
+            suffix += 1
+            run_id = f"{timestamp}-{suffix:02d}"
+        return run_id
+
+    @staticmethod
+    def _to_jsonable(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {str(k): RunArtifactManager._to_jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [RunArtifactManager._to_jsonable(v) for v in value]
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, (datetime, pd.Timestamp)):
+            return pd.Timestamp(value).isoformat()
+        return value
+
+    def artifact_path(self, filename: str) -> Path:
+        return self.output_dir / filename
+
+    def register_artifact(self, name: str, artifact_path: Path) -> None:
+        self._artifacts[name] = Path(artifact_path).name
+
+    def write_config_snapshot(self, config: dict[str, Any]) -> Path:
+        output_path = self.artifact_path(CONFIG_FILENAME)
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump(self._to_jsonable(config), fh, indent=2, sort_keys=True)
+        self.register_artifact("config", output_path)
+        return output_path
+
+    def write_manifest(
+        self,
+        status: str,
+        config_source: str = "",
+        error_message: str = "",
+    ) -> Path:
+        output_path = self.artifact_path(MANIFEST_FILENAME)
+        artifacts = dict(self._artifacts)
+        artifacts["manifest"] = MANIFEST_FILENAME
+
+        payload = {
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "output_dir": str(self.output_dir),
+            "strategy_name": self.strategy_name,
+            "benchmark_symbol": self.benchmark_symbol,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "status": status,
+            "config_source": str(config_source or ""),
+            "artifacts": dict(sorted(artifacts.items())),
+            "artifact_files": sorted(set(artifacts.values())),
+        }
+        if error_message:
+            payload["error_message"] = str(error_message)
+
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+        self.register_artifact("manifest", output_path)
+        return output_path

--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -16,6 +16,7 @@ from src.engine.broker import Broker
 from src.engine.portfolio import Portfolio
 from src.engine.order_builder import OrderBuilder
 from src.engine.metrics import METRICS_FILENAME, compute_backtest_metrics, write_metrics_json
+from src.engine.run_artifacts import RunArtifactManager
 from src.strategy.momentum import MomentumStrategy
 from src.strategy.base import BaseStrategy, StrategySignal
 
@@ -625,6 +626,7 @@ class DailySimulator:
 
         historical_data = self._history_until(trading_date)
 
+
         signals = self.strategy.generate_signals(
             decision_date=trading_date,
             market_data=historical_data,
@@ -650,6 +652,8 @@ class DailySimulator:
         end_date: str | pd.Timestamp | None = None,
         benchmark_symbol: str = "",
         benchmark_output_filename: str = BENCHMARK_EQUITY_FILENAME,
+        run_config: dict[str, Any] | None = None,
+        config_source: str = "",
     ) -> dict[str, pd.DataFrame]:
         self._portfolio_history.clear()
         self._positions_history.clear()
@@ -665,76 +669,123 @@ class DailySimulator:
 
         if not trading_dates:
             raise ValueError("No trading dates found for the requested range.")
-        
-        next_date_map = self._next_trading_date_map(trading_dates)
 
-        for trading_date in trading_dates:
-            self._process_day(
-                trading_date=trading_date,
-                next_execution_date=next_date_map.get(trading_date),
-            )
-        portfolio_history = pd.DataFrame(self._portfolio_history)
-        positions_history = pd.DataFrame(self._positions_history)
-        trade_history = pd.DataFrame(self._trade_history)
-        signal_history = pd.DataFrame(self._signal_history)
-        trade_log = pd.DataFrame(self._trade_log_history, columns=TRADE_LOG_COLUMNS)
-
-        if not portfolio_history.empty:
-            portfolio_history = portfolio_history.sort_values("date").reset_index(drop=True)
-
-        portfolio_snapshots = PortfolioSnapshotWriter.from_portfolio_history(portfolio_history)
-        position_snapshots = PositionSnapshotWriter.from_positions_history(
-            positions_history=positions_history,
-            portfolio_snapshots=portfolio_snapshots,
-        )
-
-        if not positions_history.empty:
-            positions_history = positions_history.sort_values(
-                ["date", "symbol"]
-            ).reset_index(drop=True)
-
-        if not trade_history.empty:
-            trade_history = trade_history.sort_values(
-                ["date", "symbol", "side"]
-
-            ).reset_index(drop=True)
-
-        if not signal_history.empty:
-            signal_history = signal_history.sort_values(
-                ["date", "symbol", "action"]
-            ).reset_index(drop=True)
-
-        if not trade_log.empty:
-            trade_log = trade_log.sort_values(
-                ["decision_date", "symbol", "side", "order_id"]
-            ).reset_index(drop=True)
-
-        benchmark_curve = BenchmarkComparator.build_benchmark_curve(
-            market_data=self.market_data,
-            portfolio_snapshots=portfolio_snapshots,
+        artifact_manager = RunArtifactManager(
+            base_output_dir=BACKTEST_OUTPUTS_DIR,
+            strategy_name=self.strategy.__class__.__name__,
             benchmark_symbol=benchmark_symbol,
-            initial_capital=float(getattr(self.portfolio, "initial_cash", 0.0)),
-            price_column=self.price_column,
+            start_date=self._format_datetime(trading_dates[0]),
+            end_date=self._format_datetime(trading_dates[-1]),
         )
 
-        BACKTEST_OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
-        trade_log_path = BACKTEST_OUTPUTS_DIR / TRADE_LOG_FILENAME
-        portfolio_snapshots_path = BACKTEST_OUTPUTS_DIR / PORTFOLIO_SNAPSHOT_FILENAME
-        position_snapshots_path = BACKTEST_OUTPUTS_DIR / POSITION_SNAPSHOT_FILENAME
-        benchmark_curve_path = BACKTEST_OUTPUTS_DIR / str(benchmark_output_filename or BENCHMARK_EQUITY_FILENAME)
-        metrics_path = BACKTEST_OUTPUTS_DIR / BACKTEST_METRICS_FILENAME
+        resolved_run_config = run_config or {
+            "strategy_name": self.strategy.__class__.__name__,
+            "strategy_parameters": dict(getattr(self.strategy, "__dict__", {})),
+            "broker": {
+                "commission_rate": float(getattr(self.broker, "commission_rate", 0.0) or 0.0),
+                "slippage_rate": float(getattr(self.broker, "slippage_rate", 0.0) or 0.0),
+                "fractional_shares": bool(getattr(self.broker, "fractional_shares", False)),
+            },
+            "portfolio": {
+                "initial_cash": float(getattr(self.portfolio, "initial_cash", 0.0) or 0.0),
+            },
+            "run": {
+                "start_date": self._format_datetime(trading_dates[0]),
+                "end_date": self._format_datetime(trading_dates[-1]),
+                "benchmark_symbol": str(benchmark_symbol or ""),
+                "price_column": self.price_column,
+            },
+        }
+        config_path = artifact_manager.write_config_snapshot(resolved_run_config)
 
-        trade_log.to_csv(trade_log_path, index=False)
-        PortfolioSnapshotWriter.write_csv(portfolio_snapshots, portfolio_snapshots_path)
-        PositionSnapshotWriter.write_csv(position_snapshots, position_snapshots_path)
-        BenchmarkComparator.write_csv(benchmark_curve, benchmark_curve_path)
+        try:
+            next_date_map = self._next_trading_date_map(trading_dates)
 
-        backtest_metrics = compute_backtest_metrics(
-            strategy_equity_curve=portfolio_snapshots,
-            benchmark_equity_curve=benchmark_curve,
-            trade_history=trade_history,
-        )
-        write_metrics_json(backtest_metrics, metrics_path)
+            for trading_date in trading_dates:
+                self._process_day(
+                    trading_date=trading_date,
+                    next_execution_date=next_date_map.get(trading_date),
+                )
+
+            portfolio_history = pd.DataFrame(self._portfolio_history)
+            positions_history = pd.DataFrame(self._positions_history)
+            trade_history = pd.DataFrame(self._trade_history)
+            signal_history = pd.DataFrame(self._signal_history)
+            trade_log = pd.DataFrame(self._trade_log_history, columns=TRADE_LOG_COLUMNS)
+
+            if not portfolio_history.empty:
+                portfolio_history = portfolio_history.sort_values("date").reset_index(drop=True)
+
+            portfolio_snapshots = PortfolioSnapshotWriter.from_portfolio_history(portfolio_history)
+            position_snapshots = PositionSnapshotWriter.from_positions_history(
+                positions_history=positions_history,
+                portfolio_snapshots=portfolio_snapshots,
+            )
+
+            if not positions_history.empty:
+                positions_history = positions_history.sort_values(
+                    ["date", "symbol"]
+                ).reset_index(drop=True)
+
+            if not trade_history.empty:
+                trade_history = trade_history.sort_values(
+                    ["date", "symbol", "side"]
+                ).reset_index(drop=True)
+
+            if not signal_history.empty:
+                signal_history = signal_history.sort_values(
+                    ["date", "symbol", "action"]
+                ).reset_index(drop=True)
+
+            if not trade_log.empty:
+                trade_log = trade_log.sort_values(
+                    ["decision_date", "symbol", "side", "order_id"]
+                ).reset_index(drop=True)
+
+            benchmark_curve = BenchmarkComparator.build_benchmark_curve(
+                market_data=self.market_data,
+                portfolio_snapshots=portfolio_snapshots,
+                benchmark_symbol=benchmark_symbol,
+                initial_capital=float(getattr(self.portfolio, "initial_cash", 0.0)),
+                price_column=self.price_column,
+            )
+
+            trade_log_path = artifact_manager.artifact_path(TRADE_LOG_FILENAME)
+            portfolio_snapshots_path = artifact_manager.artifact_path(PORTFOLIO_SNAPSHOT_FILENAME)
+            position_snapshots_path = artifact_manager.artifact_path(POSITION_SNAPSHOT_FILENAME)
+            benchmark_curve_path = artifact_manager.artifact_path(
+                str(benchmark_output_filename or BENCHMARK_EQUITY_FILENAME)
+            )
+            metrics_path = artifact_manager.artifact_path(BACKTEST_METRICS_FILENAME)
+
+            trade_log.to_csv(trade_log_path, index=False)
+            artifact_manager.register_artifact("trade_log", trade_log_path)
+            PortfolioSnapshotWriter.write_csv(portfolio_snapshots, portfolio_snapshots_path)
+            artifact_manager.register_artifact("portfolio_snapshots", portfolio_snapshots_path)
+            PositionSnapshotWriter.write_csv(position_snapshots, position_snapshots_path)
+            artifact_manager.register_artifact("position_snapshots", position_snapshots_path)
+            BenchmarkComparator.write_csv(benchmark_curve, benchmark_curve_path)
+            artifact_manager.register_artifact("benchmark_curve", benchmark_curve_path)
+
+            backtest_metrics = compute_backtest_metrics(
+                strategy_equity_curve=portfolio_snapshots,
+                benchmark_equity_curve=benchmark_curve,
+                trade_history=trade_history,
+            )
+            write_metrics_json(backtest_metrics, metrics_path)
+            artifact_manager.register_artifact("backtest_metrics", metrics_path)
+
+            manifest_path = artifact_manager.write_manifest(
+                status="completed",
+                config_source=config_source,
+            )
+        except Exception as exc:
+            artifact_manager.write_manifest(
+                status="failed",
+                config_source=config_source,
+                error_message=str(exc),
+            )
+            raise
 
         return {
             "portfolio_history": portfolio_history,
@@ -751,6 +802,10 @@ class DailySimulator:
             "benchmark_curve_path": benchmark_curve_path,
             "backtest_metrics": backtest_metrics,
             "backtest_metrics_path": metrics_path,
+            "run_id": artifact_manager.run_id,
+            "output_dir": artifact_manager.output_dir,
+            "config_path": config_path,
+            "manifest_path": manifest_path,
         }
 
 

--- a/src/engine/test_run_artifacts.py
+++ b/src/engine/test_run_artifacts.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+import src.engine.simulator as simulator_module
+from src.engine.broker import Broker
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import (
+    BACKTEST_METRICS_FILENAME,
+    BENCHMARK_EQUITY_FILENAME,
+    DailySimulator,
+    PORTFOLIO_SNAPSHOT_FILENAME,
+    POSITION_SNAPSHOT_FILENAME,
+    TRADE_LOG_FILENAME,
+)
+from src.strategy.base import BaseStrategy
+
+
+class EmptyStrategy(BaseStrategy):
+    def generate_signals(self, decision_date, market_data, portfolio):
+        return []
+
+
+class RunArtifactsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_output_dir = simulator_module.BACKTEST_OUTPUTS_DIR
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        simulator_module.BACKTEST_OUTPUTS_DIR = Path(self._tmp_dir.name) / "outputs" / "backtests"
+
+    def tearDown(self) -> None:
+        simulator_module.BACKTEST_OUTPUTS_DIR = self._original_output_dir
+        self._tmp_dir.cleanup()
+
+    @staticmethod
+    def _build_market_data() -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 100.0},
+                {"date": "2024-01-03", "symbol": "AAA", "adj_close": 101.0},
+                {"date": "2024-01-04", "symbol": "AAA", "adj_close": 102.0},
+                {"date": "2024-01-02", "symbol": "SPY", "adj_close": 400.0},
+                {"date": "2024-01-03", "symbol": "SPY", "adj_close": 402.0},
+                {"date": "2024-01-04", "symbol": "SPY", "adj_close": 404.0},
+            ]
+        )
+
+    def _build_simulator(self) -> DailySimulator:
+        return DailySimulator(
+            market_data=self._build_market_data(),
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=10000.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=True),
+            price_column="adj_close",
+        )
+
+    def test_backtest_run_writes_self_contained_artifacts_and_manifest(self) -> None:
+        simulator = self._build_simulator()
+        run_config = {
+            "strategy": {"name": "EmptyStrategy"},
+            "execution": {"commission_rate": 0.0, "slippage_rate": 0.0},
+            "run": {"seed": 1},
+        }
+
+        results = simulator.run(
+            start_date="2024-01-02",
+            end_date="2024-01-04",
+            benchmark_symbol="SPY",
+            run_config=run_config,
+            config_source="config/settings.yaml",
+        )
+
+        output_dir = results["output_dir"]
+        self.assertTrue(output_dir.exists())
+        self.assertEqual(output_dir.parent, simulator_module.BACKTEST_OUTPUTS_DIR)
+
+        expected_files = {
+            TRADE_LOG_FILENAME,
+            PORTFOLIO_SNAPSHOT_FILENAME,
+            POSITION_SNAPSHOT_FILENAME,
+            BENCHMARK_EQUITY_FILENAME,
+            BACKTEST_METRICS_FILENAME,
+            "config.json",
+            "manifest.json",
+        }
+        self.assertTrue(expected_files.issubset({path.name for path in output_dir.iterdir()}))
+
+        config_path = results["config_path"]
+        with config_path.open("r", encoding="utf-8") as fh:
+            stored_config = json.load(fh)
+        self.assertEqual(stored_config, run_config)
+
+        manifest_path = results["manifest_path"]
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+
+        self.assertEqual(manifest["run_id"], results["run_id"])
+        self.assertEqual(manifest["status"], "completed")
+        self.assertEqual(manifest["strategy_name"], "EmptyStrategy")
+        self.assertEqual(manifest["benchmark_symbol"], "SPY")
+        self.assertEqual(manifest["config_source"], "config/settings.yaml")
+        self.assertIn("trade_log", manifest["artifacts"])
+        self.assertIn("backtest_metrics", manifest["artifacts"])
+        self.assertIn("manifest.json", manifest["artifact_files"])
+        self.assertIn("config.json", manifest["artifact_files"])
+
+    def test_repeated_runs_create_unique_directories_without_overwrite(self) -> None:
+        simulator = self._build_simulator()
+
+        first = simulator.run(start_date="2024-01-02", end_date="2024-01-04", benchmark_symbol="SPY")
+        second = simulator.run(start_date="2024-01-02", end_date="2024-01-04", benchmark_symbol="SPY")
+
+        first_output_dir = first["output_dir"]
+        second_output_dir = second["output_dir"]
+
+        self.assertNotEqual(first["run_id"], second["run_id"])
+        self.assertNotEqual(first_output_dir, second_output_dir)
+        self.assertTrue(first_output_dir.exists())
+        self.assertTrue(second_output_dir.exists())
+
+        first_trade_log = pd.read_csv(first["trade_log_path"])
+        second_trade_log = pd.read_csv(second["trade_log_path"])
+        self.assertEqual(len(first_trade_log), len(second_trade_log))
+
+        runs_on_disk = [p for p in simulator_module.BACKTEST_OUTPUTS_DIR.iterdir() if p.is_dir()]
+        self.assertGreaterEqual(len(runs_on_disk), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #26

## What changed
- added a per-run artifact folder structure under `outputs/backtests/`
- saved trade logs, portfolio snapshots, position snapshots, benchmark outputs, and metrics into each run folder
- added a run manifest file for artifact discovery
- saved the effective config used for each run
- prevented silent overwriting by isolating outputs per run

## Why
This PR makes each backtest run self-contained and reproducible so outputs can be traced, discovered, and reused later.

## Notes
The run artifact structure is designed to stay simple, explicit, and ready for future reporting or UI layers.