### PR TITLE
feat(cli): add backtest entrypoint

### DIFF
--- a/src/cli/backtest.py
+++ b/src/cli/backtest.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.data.features import add_basic_features
+from src.data.loader import get_benchmark_symbol, load_market_data, load_yaml
+from src.engine.broker import Broker
+from src.engine.portfolio import Portfolio
+from src.engine.simulator import DailySimulator
+from src.strategy.momentum import MomentumStrategy
+
+
+def _parse_date(value: str, flag_name: str) -> pd.Timestamp:
+    try:
+        return pd.Timestamp(value)
+    except Exception as exc:
+        raise ValueError(f"Invalid {flag_name} date format: {value!r}. Use YYYY-MM-DD.") from exc
+
+
+def _load_universe_symbols(settings_path: Path) -> list[str]:
+    universe_path = settings_path.parent / "universe.yaml"
+    data = load_yaml(universe_path)
+    symbols = data.get("universe", {}).get("symbols", [])
+
+    if not isinstance(symbols, list) or not symbols:
+        raise ValueError(f"No symbols found in universe file: {universe_path}")
+
+    cleaned = [str(s).strip().upper() for s in symbols if str(s).strip()]
+    if not cleaned:
+        raise ValueError(f"Universe symbols are empty after cleaning: {universe_path}")
+
+    return cleaned
+
+
+def run_backtest(
+    config_path: Path,
+    start_date_override: str | None = None,
+    end_date_override: str | None = None,
+) -> dict[str, Any]:
+    settings = load_yaml(config_path)
+
+    portfolio_cfg = settings.get("portfolio", {})
+    execution_cfg = settings.get("execution", {})
+    strategy_cfg = settings.get("strategy", {})
+    benchmark_symbol = get_benchmark_symbol(settings)
+
+    start_date = start_date_override or settings.get("data", {}).get("start_date")
+    end_date = end_date_override if end_date_override is not None else settings.get("data", {}).get("end_date")
+
+    start_ts: pd.Timestamp | None = None
+    end_ts: pd.Timestamp | None = None
+
+    if start_date:
+        start_ts = _parse_date(str(start_date), "--start-date")
+    if end_date:
+        end_ts = _parse_date(str(end_date), "--end-date")
+
+    if start_ts is not None and end_ts is not None and start_ts > end_ts:
+        raise ValueError(
+            f"Invalid date range: start date {start_ts.date()} is after end date {end_ts.date()}."
+        )
+
+    symbols = _load_universe_symbols(config_path)
+    market_df = load_market_data(symbols=symbols + ([benchmark_symbol] if benchmark_symbol and benchmark_symbol not in symbols else []))
+    features_df = add_basic_features(market_df)
+
+    portfolio = Portfolio(initial_cash=float(portfolio_cfg.get("initial_cash", 0.0)))
+    broker = Broker(
+        commission_rate=float(execution_cfg.get("commission_rate", 0.0)),
+        slippage_rate=float(execution_cfg.get("slippage_rate", 0.0)),
+        fractional_shares=bool(portfolio_cfg.get("fractional_shares", True)),
+    )
+    strategy = MomentumStrategy(
+        max_open_positions=int(portfolio_cfg.get("max_open_positions", 1)),
+        top_k=int(strategy_cfg.get("top_k", 1)),
+        min_score=0.0,
+    )
+
+    simulator = DailySimulator(
+        market_data=features_df,
+        strategy=strategy,
+        broker=broker,
+        portfolio=portfolio,
+        price_column="adj_close",
+    )
+
+    run_config = {
+        "settings": settings,
+        "cli_overrides": {
+            "start_date": str(start_ts.date()) if start_ts is not None else None,
+            "end_date": str(end_ts.date()) if end_ts is not None else None,
+        },
+    }
+
+    results = simulator.run(
+        start_date=start_ts,
+        end_date=end_ts,
+        benchmark_symbol=benchmark_symbol,
+        run_config=run_config,
+        config_source=str(config_path),
+    )
+    return results
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the full backtest pipeline.")
+    parser.add_argument("--config", required=True, help="Path to settings YAML file.")
+    parser.add_argument("--start-date", help="Optional override start date (YYYY-MM-DD).")
+    parser.add_argument("--end-date", help="Optional override end date (YYYY-MM-DD).")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"[ERROR] Config file not found: {config_path}", file=sys.stderr)
+        return 2
+
+    try:
+        results = run_backtest(
+            config_path=config_path,
+            start_date_override=args.start_date,
+            end_date_override=args.end_date,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"[ERROR] Backtest failed unexpectedly: {exc}", file=sys.stderr)
+        return 1
+
+    portfolio_snapshots = results.get("portfolio_snapshots", pd.DataFrame())
+    sim_start = "N/A"
+    sim_end = "N/A"
+    final_equity = "N/A"
+
+    if not portfolio_snapshots.empty:
+        sim_start = str(pd.Timestamp(portfolio_snapshots.iloc[0]["date"]).date())
+        sim_end = str(pd.Timestamp(portfolio_snapshots.iloc[-1]["date"]).date())
+        final_equity = f"{float(portfolio_snapshots.iloc[-1]['total_equity']):.2f}"
+
+    trade_count = int(len(results.get("trade_history", pd.DataFrame())))
+    benchmark = ""
+    benchmark_curve = results.get("benchmark_curve", pd.DataFrame())
+    if isinstance(benchmark_curve, pd.DataFrame) and not benchmark_curve.empty:
+        benchmark = str(benchmark_curve.iloc[0].get("benchmark_symbol", ""))
+
+    print("-" * 60)
+    print("Backtest completed")
+    print(f"Run ID: {results.get('run_id')}")
+    print(f"Output directory: {results.get('output_dir')}")
+    print(f"Window: {sim_start} -> {sim_end}")
+    print(f"Trade count: {trade_count}")
+    print(f"Final equity: {final_equity}")
+    print(f"Benchmark: {benchmark or 'N/A'}")
+    print(f"Metrics file: {results.get('backtest_metrics_path')}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/test_backtest_cli.py
+++ b/src/cli/test_backtest_cli.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+
+import src.data.loader as loader_module
+import src.engine.simulator as simulator_module
+from src.cli.backtest import main
+
+
+class BacktestCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp_dir.name)
+
+        self._original_raw = loader_module.RAW_DATA_DIR
+        self._original_outputs = simulator_module.BACKTEST_OUTPUTS_DIR
+
+        loader_module.RAW_DATA_DIR = self.tmp_path / "data" / "raw"
+        simulator_module.BACKTEST_OUTPUTS_DIR = self.tmp_path / "outputs" / "backtests"
+        loader_module.RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        self.config_path = self.tmp_path / "config" / "settings.yaml"
+        self.universe_path = self.tmp_path / "config" / "universe.yaml"
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.config_path.write_text(
+            """
+portfolio:
+  initial_cash: 1000.0
+  max_open_positions: 2
+  fractional_shares: true
+execution:
+  commission_rate: 0.001
+  slippage_rate: 0.001
+strategy:
+  top_k: 2
+benchmark:
+  benchmark_symbol: "SPY"
+data:
+  start_date: "2024-01-02"
+  end_date: "2024-01-05"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        self.universe_path.write_text(
+            """
+universe:
+  symbols: ["AAA"]
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        self._write_symbol("AAA", [10.0, 11.0, 12.0, 11.5])
+        self._write_symbol("SPY", [100.0, 101.0, 102.0, 103.0])
+
+    def tearDown(self) -> None:
+        loader_module.RAW_DATA_DIR = self._original_raw
+        simulator_module.BACKTEST_OUTPUTS_DIR = self._original_outputs
+        self._tmp_dir.cleanup()
+
+    def _write_symbol(self, symbol: str, closes: list[float]) -> None:
+        dates = pd.date_range("2024-01-02", periods=len(closes), freq="D")
+        df = pd.DataFrame(
+            {
+                "date": dates,
+                "symbol": symbol,
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "adj_close": closes,
+                "volume": [1000] * len(closes),
+                "dividends": [0.0] * len(closes),
+                "stock_splits": [0.0] * len(closes),
+            }
+        )
+        df.to_parquet(loader_module.RAW_DATA_DIR / f"{symbol}.parquet", index=False)
+
+    def test_cli_accepts_config_and_runs_full_backtest(self) -> None:
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["--config", str(self.config_path)])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err.getvalue(), "")
+        stdout = out.getvalue()
+        self.assertIn("Backtest completed", stdout)
+        self.assertIn("Run ID:", stdout)
+        self.assertIn("Output directory:", stdout)
+        self.assertIn("Metrics file:", stdout)
+
+        run_dirs = [p for p in simulator_module.BACKTEST_OUTPUTS_DIR.iterdir() if p.is_dir()]
+        self.assertEqual(len(run_dirs), 1)
+        files = {p.name for p in run_dirs[0].iterdir()}
+        self.assertIn("trade_log.csv", files)
+        self.assertIn("backtest_metrics.json", files)
+        self.assertIn("manifest.json", files)
+
+    def test_cli_accepts_date_overrides(self) -> None:
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(
+                [
+                    "--config",
+                    str(self.config_path),
+                    "--start-date",
+                    "2024-01-03",
+                    "--end-date",
+                    "2024-01-04",
+                ]
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err.getvalue(), "")
+        self.assertIn("Window: 2024-01-03 -> 2024-01-04", out.getvalue())
+
+    def test_cli_invalid_date_returns_readable_error_and_nonzero(self) -> None:
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["--config", str(self.config_path), "--start-date", "bad-date"])
+
+        self.assertEqual(code, 2)
+        self.assertIn("Invalid --start-date date format", err.getvalue())
+
+    def test_cli_start_after_end_returns_readable_error_and_nonzero(self) -> None:
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(
+                [
+                    "--config",
+                    str(self.config_path),
+                    "--start-date",
+                    "2024-01-05",
+                    "--end-date",
+                    "2024-01-03",
+                ]
+            )
+
+        self.assertEqual(code, 2)
+        self.assertIn("start date 2024-01-05 is after end date 2024-01-03", err.getvalue())
+
+    def test_cli_missing_config_path_returns_nonzero(self) -> None:
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["--config", str(self.tmp_path / "missing.yaml")])
+
+        self.assertEqual(code, 2)
+        self.assertIn("Config file not found", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #28

## What changed
- added a runnable CLI entrypoint for the full backtest pipeline
- accepted config path input from the command line
- added optional date range overrides
- printed a short run summary after execution
- saved run results automatically to the run artifact folder

## Why
This PR makes the full backtest pipeline easier to run without editing source code.

## Notes
The CLI is designed to stay simple, readable, and aligned with the existing config-driven workflow.