### PR TITLE
feat(config): define strategy evaluation protocol

### DIFF
--- a/config/evaluation/m3_protocol.yaml
+++ b/config/evaluation/m3_protocol.yaml
@@ -1,0 +1,85 @@
+protocol:
+  name: m3_official_evaluation
+  milestone: M3
+  version: 1
+  description: Official comparison contract for M3 strategy vs baseline evaluations.
+
+data:
+  source: yfinance
+  start_date: "2020-01-01"
+  end_date: "2024-12-31"
+  interval: "1d"
+  auto_adjust: false
+  actions: true
+
+universe:
+  name: m3_nasdaq_core_10
+  symbols:
+    - AAPL
+    - MSFT
+    - NVDA
+    - AMZN
+    - META
+    - TSLA
+    - AMD
+    - NFLX
+    - QCOM
+    - GOOGL
+
+benchmark:
+  benchmark_symbol: "QQQ"
+
+portfolio:
+  initial_cash: 10000.0
+  currency: "USD"
+  max_open_positions: 2
+  max_position_weight: 0.5
+  fractional_shares: true
+
+execution:
+  commission_rate: 0.001
+  slippage_rate: 0.001
+  execution_timing: "next_open"
+
+strategy:
+  name: momentum_v0
+  rebalance_frequency: "daily"
+  lookback_short: 20
+  lookback_long: 50
+  top_k: 2
+
+output:
+  save_trades_csv: true
+  save_portfolio_csv: true
+  save_positions_csv: true
+  save_metrics_json: true
+
+m3_requirements:
+  simulator_assumptions:
+    - Decisions are made with information available up to the decision date only.
+    - Orders are executed on the next tradable session.
+    - Portfolio constraints and position sizing must use configured limits.
+    - Strategy performance is compared against configured benchmark equity curve.
+    - Metrics and run artifacts are exported for every run.
+  required_outputs:
+    - trade_log.csv
+    - daily_portfolio_snapshots.csv
+    - daily_position_snapshots.csv
+    - benchmark_equity_curve.csv
+    - backtest_metrics.json
+    - manifest.json
+    - config.json
+  required_metrics:
+    strategy:
+      - cumulative_return
+      - max_drawdown
+      - volatility
+      - trade_count
+      - win_rate
+      - sharpe_ratio
+      - return_over_max_drawdown
+    benchmark:
+      - cumulative_return
+      - max_drawdown
+      - volatility
+      - sharpe_ratio

--- a/docs/m3_evaluation_protocol.md
+++ b/docs/m3_evaluation_protocol.md
@@ -1,0 +1,70 @@
+# M3 Evaluation Protocol (Official Contract)
+
+The file `config/evaluation/m3_protocol.yaml` is the **single official evaluation setup for M3**.  
+All momentum strategy variants and baseline strategies must run under this same protocol.
+
+## Why this exists
+
+M3 comparisons must be reproducible and fair. This protocol fixes:
+- the date window
+- the comparison universe
+- the benchmark
+- initial capital
+- simulator assumptions
+- required artifacts and metrics
+
+## Official setup
+
+- **Protocol file:** `config/evaluation/m3_protocol.yaml`
+- **Backtest window:** `2020-01-01` to `2024-12-31`
+- **Universe:** `AAPL, MSFT, NVDA, AMZN, META, TSLA, AMD, NFLX, QCOM, GOOGL`
+- **Benchmark:** `QQQ`
+- **Starting capital:** `10000.0`
+
+## Fixed simulator assumptions for M3
+
+M3 runs must use the same execution assumptions already implemented in the simulator:
+
+1. Decision-date data isolation (no forward-looking leakage).
+2. Next-session execution behavior for orders.
+3. Configured portfolio constraints (position limits/weights).
+4. Benchmark equity curve generation from the configured benchmark symbol.
+5. Consistent metrics generation and run artifact export.
+
+These assumptions are documented in the protocol file under `m3_requirements.simulator_assumptions` and enforced by existing simulator/metrics/artifact code paths.
+
+## Required outputs for every M3 run
+
+Each run must produce, at minimum:
+- `trade_log.csv`
+- `daily_portfolio_snapshots.csv`
+- `daily_position_snapshots.csv`
+- `benchmark_equity_curve.csv`
+- `backtest_metrics.json`
+- `manifest.json`
+- `config.json`
+
+## Required metrics for every M3 run
+
+At minimum, reported metrics must include:
+
+- **Strategy:** `cumulative_return`, `max_drawdown`, `volatility`, `trade_count`, `win_rate`, `sharpe_ratio`, `return_over_max_drawdown`
+- **Benchmark:** `cumulative_return`, `max_drawdown`, `volatility`, `sharpe_ratio`
+
+## How to run with the official protocol
+
+Use the standard backtest entrypoint and point it to the protocol config:
+
+```bash
+python -m src.cli.backtest --config config/evaluation/m3_protocol.yaml
+```
+
+Optional date override (if you need a subset run) still uses the same protocol assumptions:
+
+```bash
+python -m src.cli.backtest --config config/evaluation/m3_protocol.yaml --start-date 2021-01-01 --end-date 2021-12-31
+```
+
+## Guidance for future baselines
+
+Any future M3 baseline must reuse `config/evaluation/m3_protocol.yaml` directly (or a versioned successor file when the protocol itself is intentionally revised). Do not change Python source files for routine comparison runs.

--- a/src/cli/backtest.py
+++ b/src/cli/backtest.py
@@ -22,17 +22,22 @@ def _parse_date(value: str, flag_name: str) -> pd.Timestamp:
         raise ValueError(f"Invalid {flag_name} date format: {value!r}. Use YYYY-MM-DD.") from exc
 
 
-def _load_universe_symbols(settings_path: Path) -> list[str]:
-    universe_path = settings_path.parent / "universe.yaml"
-    data = load_yaml(universe_path)
-    symbols = data.get("universe", {}).get("symbols", [])
+def _load_universe_symbols(settings_path: Path, settings: dict[str, Any]) -> list[str]:
+    symbols = settings.get("universe", {}).get("symbols", [])
+    source = str(settings_path)
+
+    if not symbols:
+        universe_path = settings_path.parent / "universe.yaml"
+        data = load_yaml(universe_path)
+        symbols = data.get("universe", {}).get("symbols", [])
+        source = str(universe_path)
 
     if not isinstance(symbols, list) or not symbols:
-        raise ValueError(f"No symbols found in universe file: {universe_path}")
+        raise ValueError(f"No symbols found in universe config: {source}")
 
     cleaned = [str(s).strip().upper() for s in symbols if str(s).strip()]
     if not cleaned:
-        raise ValueError(f"Universe symbols are empty after cleaning: {universe_path}")
+        raise ValueError(f"Universe symbols are empty after cleaning: {source}")
 
     return cleaned
 
@@ -65,7 +70,7 @@ def run_backtest(
             f"Invalid date range: start date {start_ts.date()} is after end date {end_ts.date()}."
         )
 
-    symbols = _load_universe_symbols(config_path)
+    symbols = _load_universe_symbols(config_path, settings)
     market_df = load_market_data(symbols=symbols + ([benchmark_symbol] if benchmark_symbol and benchmark_symbol not in symbols else []))
     features_df = add_basic_features(market_df)
 

--- a/src/cli/test_backtest_cli.py
+++ b/src/cli/test_backtest_cli.py
@@ -131,6 +131,42 @@ universe:
         self.assertEqual(err.getvalue(), "")
         self.assertIn("Window: 2024-01-03 -> 2024-01-04", out.getvalue())
 
+    def test_cli_supports_inline_universe_in_config(self) -> None:
+        inline_config = self.tmp_path / "config" / "m3_protocol.yaml"
+        inline_config.write_text(
+            """
+portfolio:
+  initial_cash: 1000.0
+  max_open_positions: 2
+  fractional_shares: true
+execution:
+  commission_rate: 0.001
+  slippage_rate: 0.001
+strategy:
+  top_k: 2
+benchmark:
+  benchmark_symbol: "SPY"
+data:
+  start_date: "2024-01-02"
+  end_date: "2024-01-05"
+universe:
+  symbols: ["AAA"]
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["--config", str(inline_config)])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err.getvalue(), "")
+        self.assertIn("Backtest completed", out.getvalue())
+
+
     def test_cli_invalid_date_returns_readable_error_and_nonzero(self) -> None:
         out = io.StringIO()
         err = io.StringIO()

--- a/src/data/test_m3_protocol_config.py
+++ b/src/data/test_m3_protocol_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from src.data.loader import load_yaml
+
+
+class M3ProtocolConfigTests(unittest.TestCase):
+    def test_official_m3_protocol_config_has_required_fields(self) -> None:
+        protocol_path = Path("config/evaluation/m3_protocol.yaml")
+        self.assertTrue(protocol_path.exists(), f"Missing protocol file: {protocol_path}")
+
+        data = load_yaml(protocol_path)
+
+        self.assertIn("protocol", data)
+        self.assertEqual(data["protocol"].get("milestone"), "M3")
+
+        for key in ["data", "universe", "benchmark", "portfolio", "execution", "m3_requirements"]:
+            self.assertIn(key, data)
+
+        self.assertTrue(data["data"].get("start_date"))
+        self.assertTrue(data["data"].get("end_date"))
+        self.assertTrue(data["universe"].get("symbols"))
+        self.assertTrue(data["benchmark"].get("benchmark_symbol"))
+        self.assertIsNotNone(data["portfolio"].get("initial_cash"))
+
+        requirements = data["m3_requirements"]
+        self.assertTrue(requirements.get("required_outputs"))
+        self.assertTrue(requirements.get("required_metrics"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #44

## What changed
- added an official M3 strategy evaluation protocol
- defined the shared backtest window, comparison universe, benchmark, and starting capital
- fixed the simulator assumptions all compared strategies must follow
- defined the required outputs and metrics for every evaluation run
- documented how future M3 baselines should reuse the same setup

## Why
This PR creates a single comparison contract for M3 so momentum and baseline strategies can be evaluated fairly and reproducibly under identical assumptions.

## Notes
The protocol is intended to be the official evaluation setup for the rest of M3 and should be reusable without source-code edits.