### PR TITLE
feat(engine): implement buy-and-hold benchmark

### DIFF
--- a/src/engine/simulator.py
+++ b/src/engine/simulator.py
@@ -218,19 +218,30 @@ class BenchmarkComparator:
 
         curve = canonical_dates.merge(benchmark_prices, on="date", how="left").sort_values("date")
         curve["benchmark_symbol"] = symbol
-        curve["benchmark_price"] = curve["benchmark_price"].ffill().bfill()
 
-        if curve["benchmark_price"].isna().all():
+        first_price_index = curve["benchmark_price"].first_valid_index()
+        if first_price_index is None:
             curve["benchmark_return"] = 0.0
             curve["benchmark_equity"] = float(initial_capital)
             curve["cumulative_return"] = 0.0
             return curve[BENCHMARK_EQUITY_COLUMNS]
 
-        curve["benchmark_return"] = curve["benchmark_price"].pct_change().fillna(0.0)
-        curve["benchmark_return"] = curve["benchmark_return"].replace([pd.NA, float("inf"), float("-inf")], 0.0).fillna(0.0)
+        curve["benchmark_price"] = curve["benchmark_price"].ffill()
 
+        first_benchmark_price = float(curve.loc[first_price_index, "benchmark_price"])
         starting_capital = float(initial_capital)
-        curve["benchmark_equity"] = starting_capital * (1.0 + curve["benchmark_return"]).cumprod()
+        benchmark_shares = 0.0
+        if first_benchmark_price > 0.0:
+            benchmark_shares = starting_capital / first_benchmark_price
+
+        curve["benchmark_equity"] = float(starting_capital)
+        invested_mask = curve.index >= first_price_index
+        curve.loc[invested_mask, "benchmark_equity"] = (
+            benchmark_shares * curve.loc[invested_mask, "benchmark_price"]
+        )
+
+        curve["benchmark_return"] = curve["benchmark_equity"].pct_change().fillna(0.0)
+        curve["benchmark_return"] = curve["benchmark_return"].replace([pd.NA, float("inf"), float("-inf")], 0.0).fillna(0.0)
 
         if starting_capital == 0.0:
             curve["cumulative_return"] = 0.0

--- a/src/engine/test_benchmark_export.py
+++ b/src/engine/test_benchmark_export.py
@@ -65,29 +65,91 @@ class BenchmarkExportTests(unittest.TestCase):
             benchmark_symbol="QQQ",
         )
 
+
+
+        benchmark_curve = results["benchmark_curve"]
         benchmark_curve = results["benchmark_curve"]
         self.assertEqual(list(benchmark_curve.columns), BENCHMARK_EQUITY_COLUMNS)
+        self.assertEqual(list(benchmark_curve.columns), BENCHMARK_EQUITY_COLUMNS)
+        self.assertEqual(len(benchmark_curve), 4)
         self.assertEqual(len(benchmark_curve), 4)
 
+
+        dates = pd.to_datetime(benchmark_curve["date"])
         dates = pd.to_datetime(benchmark_curve["date"])
         self.assertEqual(dates.min(), pd.Timestamp("2024-01-02"))
+        self.assertEqual(dates.min(), pd.Timestamp("2024-01-02"))
+        self.assertEqual(dates.max(), pd.Timestamp("2024-01-05"))
         self.assertEqual(dates.max(), pd.Timestamp("2024-01-05"))
 
+
+        self.assertEqual(float(benchmark_curve.iloc[0]["benchmark_equity"]), 100000.0)
         self.assertEqual(float(benchmark_curve.iloc[0]["benchmark_equity"]), 100000.0)
         self.assertEqual(float(benchmark_curve.iloc[1]["benchmark_return"]), 0.0)
+        self.assertEqual(float(benchmark_curve.iloc[1]["benchmark_return"]), 0.0)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[2]["benchmark_return"]), 0.10, places=8)
         self.assertAlmostEqual(float(benchmark_curve.iloc[2]["benchmark_return"]), 0.10, places=8)
         self.assertAlmostEqual(float(benchmark_curve.iloc[3]["benchmark_equity"]), 121000.0, places=6)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[3]["benchmark_equity"]), 121000.0, places=6)
+
 
         self.assertEqual(
+        self.assertEqual(
+            list(pd.to_datetime(benchmark_curve["date"])),
             list(pd.to_datetime(benchmark_curve["date"])),
             list(pd.to_datetime(results["portfolio_snapshots"]["date"])),
+            list(pd.to_datetime(results["portfolio_snapshots"]["date"])),
+        )
         )
 
+
+        output_path = results["benchmark_curve_path"]
         output_path = results["benchmark_curve_path"]
         self.assertTrue(output_path.exists())
+        self.assertTrue(output_path.exists())
+        loaded = pd.read_csv(output_path)
         loaded = pd.read_csv(output_path)
         self.assertEqual(list(loaded.columns), BENCHMARK_EQUITY_COLUMNS)
+        self.assertEqual(list(loaded.columns), BENCHMARK_EQUITY_COLUMNS)
         self.assertEqual(len(loaded), 4)
+        self.assertEqual(len(loaded), 4)
+
+
+    def test_benchmark_remains_flat_until_first_available_price(self) -> None:
+        data = pd.DataFrame(
+            [
+                {"date": "2024-01-02", "symbol": "AAA", "adj_close": 50.0},
+                {"date": "2024-01-03", "symbol": "AAA", "adj_close": 51.0},
+                {"date": "2024-01-04", "symbol": "AAA", "adj_close": 52.0},
+                {"date": "2024-01-05", "symbol": "AAA", "adj_close": 53.0},
+                {"date": "2024-01-03", "symbol": "QQQ", "adj_close": 100.0},
+                {"date": "2024-01-04", "symbol": "QQQ", "adj_close": 105.0},
+                {"date": "2024-01-05", "symbol": "QQQ", "adj_close": 110.0},
+            ]
+        )
+
+        simulator = DailySimulator(
+            market_data=data,
+            strategy=EmptyStrategy(),
+            portfolio=Portfolio(initial_cash=100000.0),
+            broker=Broker(commission_rate=0.0, slippage_rate=0.0, fractional_shares=False),
+            price_column="adj_close",
+        )
+
+        results = simulator.run(
+            start_date="2024-01-02",
+            end_date="2024-01-05",
+            benchmark_symbol="QQQ",
+        )
+
+        benchmark_curve = results["benchmark_curve"]
+
+        self.assertTrue(pd.isna(benchmark_curve.iloc[0]["benchmark_price"]))
+        self.assertEqual(float(benchmark_curve.iloc[0]["benchmark_equity"]), 100000.0)
+        self.assertEqual(float(benchmark_curve.iloc[1]["benchmark_equity"]), 100000.0)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[2]["benchmark_equity"]), 105000.0, places=6)
+        self.assertAlmostEqual(float(benchmark_curve.iloc[3]["benchmark_equity"]), 110000.0, places=6)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #45

## What changed
- implemented a buy-and-hold benchmark for the official M3 evaluation window
- used the same benchmark asset, date range, and starting capital as the evaluation setup
- generated an aligned daily benchmark equity curve for direct comparison
- saved benchmark outputs in the run artifact folder
- kept the output machine-readable and consistent with strategy run structure

## Why
This PR adds the minimum passive baseline needed to evaluate whether the active strategy is improving outcomes over a simple buy-and-hold alternative.

## Notes
The benchmark is intentionally simple and is designed to serve as the official passive reference for M3 comparisons.