### PR TITLE
feat(engine): build baseline comparison runner

### DIFF
--- a/src/engine/comparison_runner.py
+++ b/src/engine/comparison_runner.py
@@ -274,6 +274,15 @@ def run_m3_comparison(
     portfolio_snapshots = pd.read_csv(ref_output_dir / "daily_portfolio_snapshots.csv")
     trade_history = pd.DataFrame()
     initial_capital = float(settings.get("portfolio", {}).get("initial_cash", 0.0))
+    benchmark_curve_for_metrics = pd.DataFrame(columns=["date", "benchmark_equity"])
+    if benchmark_symbol:
+        benchmark_curve_for_metrics = BenchmarkComparator.build_benchmark_curve(
+            market_data=features_df,
+            portfolio_snapshots=portfolio_snapshots,
+            benchmark_symbol=benchmark_symbol,
+            initial_capital=initial_capital,
+            price_column="adj_close",
+        )
 
     if run_buy_and_hold:
         comparator = BenchmarkComparator.build_benchmark_curve(
@@ -344,7 +353,7 @@ def run_m3_comparison(
         manager.register_artifact("equal_weight_curve", curve_path)
         metrics = compute_backtest_metrics(
             strategy_equity_curve=_build_portfolio_curve_from_column(comparator, "equal_weight_equity"),
-            benchmark_equity_curve=pd.DataFrame(columns=["date", "benchmark_equity"]),
+            benchmark_equity_curve=benchmark_curve_for_metrics,
             trade_history=trade_history,
         )
         metrics_path = manager.artifact_path("backtest_metrics.json")

--- a/src/engine/test_comparison_runner.py
+++ b/src/engine/test_comparison_runner.py
@@ -129,6 +129,18 @@ baselines:
         second_metrics = json.loads(Path(second["runs"][0]["metrics_path"]).read_text(encoding="utf-8"))
         self.assertEqual(first_metrics, second_metrics)
 
+
+    def test_equal_weight_uses_benchmark_curve_for_metrics(self) -> None:
+        self._write_config()
+        result = run_m3_comparison(config_path=self.config_path, output_root=self.output_dir)
+
+        runs_by_name = {item["name"]: item for item in result["runs"]}
+        equal_weight_metrics = json.loads(Path(runs_by_name["equal_weight"]["metrics_path"]).read_text(encoding="utf-8"))
+        buy_hold_metrics = json.loads(Path(runs_by_name["buy_and_hold"]["metrics_path"]).read_text(encoding="utf-8"))
+
+        self.assertGreater(equal_weight_metrics["benchmark"]["cumulative_return"], 0.0)
+        self.assertEqual(equal_weight_metrics["benchmark"], buy_hold_metrics["benchmark"])
+
     def test_missing_required_baseline_components_fail_clearly(self) -> None:
         self._write_config(benchmark_symbol="")
         with self.assertRaisesRegex(ValueError, "Buy-and-hold baseline requires benchmark"):


### PR DESCRIPTION
Closes #48

## What changed
- added an M3 comparison entrypoint
- executed the main strategy, baselines, and selected momentum variants in one workflow
- grouped outputs under a single structured comparison run
- preserved strategy names and comparison metadata in saved artifacts
- prevented accidental overwrites of prior comparison runs

## Why
This PR adds a unified comparison workflow so M3 evaluations can be launched consistently from one entrypoint instead of being run and combined manually.

## Notes
The runner is focused on workflow consistency and keeps the comparison process reproducible and easy to extend later.