### PR TITLE
feat(engine): add ranking summary for compared strategies

### DIFF
--- a/src/engine/comparison_ranking.py
+++ b/src/engine/comparison_ranking.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+RANKING_SUMMARY_JSON_FILENAME = "ranking_summary.json"
+STRATEGY_RANKING_CSV_FILENAME = "strategy_ranking.csv"
+
+_REQUIRED_RANKING_COLUMNS = {
+    "run_name",
+    "run_id",
+    "strategy_type",
+    "variant_name",
+    "sharpe_ratio",
+    "cumulative_return",
+    "max_drawdown",
+}
+_NUMERIC_RANKING_COLUMNS = {"sharpe_ratio", "cumulative_return", "max_drawdown"}
+_RANKING_OUTPUT_COLUMNS = [
+    "rank",
+    "run_name",
+    "run_id",
+    "strategy_type",
+    "variant_name",
+    "sharpe_ratio",
+    "cumulative_return",
+    "max_drawdown",
+    "max_drawdown_magnitude",
+    "return_over_max_drawdown",
+    "volatility",
+    "average_daily_return",
+    "trade_count",
+    "win_rate",
+    "activity_metrics_status",
+]
+_SELECTION_RULE = {
+    "description": (
+        "Rank runs by higher sharpe_ratio, then higher cumulative_return, "
+        "then lower absolute max_drawdown, then lexical run_name ordering."
+    ),
+    "primary_metric": {"name": "sharpe_ratio", "direction": "higher_is_better"},
+    "tie_breakers": [
+        {"name": "cumulative_return", "direction": "higher_is_better"},
+        {"name": "absolute_max_drawdown", "direction": "lower_is_better"},
+        {"name": "run_name", "direction": "lexical_ascending"},
+    ],
+}
+
+
+def _load_comparison_metrics(comparison_metrics_csv_path: Path) -> pd.DataFrame:
+    metrics_path = Path(comparison_metrics_csv_path)
+    if not metrics_path.exists():
+        raise FileNotFoundError(f"Missing comparison metrics input for ranking: {metrics_path}")
+
+    metrics_df = pd.read_csv(metrics_path)
+    if metrics_df.empty:
+        raise ValueError("Comparison metrics input is empty; cannot build ranking summary.")
+
+    missing_columns = sorted(_REQUIRED_RANKING_COLUMNS.difference(metrics_df.columns))
+    if missing_columns:
+        raise ValueError(f"Ranking input is missing required columns: {missing_columns}")
+
+    for column in sorted(_NUMERIC_RANKING_COLUMNS):
+        metrics_df[column] = pd.to_numeric(metrics_df[column], errors="coerce")
+        if metrics_df[column].isna().any():
+            raise ValueError(f"Ranking input has missing or non-numeric values in required metric '{column}'.")
+
+    return metrics_df
+
+
+def build_comparison_ranking(metrics_df: pd.DataFrame) -> pd.DataFrame:
+    if metrics_df.empty:
+        raise ValueError("Comparison metrics input is empty; cannot build ranking summary.")
+
+    ranked = metrics_df.copy()
+    ranked["run_name"] = ranked["run_name"].astype(str)
+    ranked["variant_name"] = ranked["variant_name"].fillna("").astype(str)
+    ranked["max_drawdown_magnitude"] = ranked["max_drawdown"].abs()
+    ranked = ranked.sort_values(
+        by=["sharpe_ratio", "cumulative_return", "max_drawdown_magnitude", "run_name"],
+        ascending=[False, False, True, True],
+        kind="mergesort",
+    ).reset_index(drop=True)
+    ranked.insert(0, "rank", range(1, len(ranked) + 1))
+
+    for column in _RANKING_OUTPUT_COLUMNS:
+        if column not in ranked.columns:
+            ranked[column] = pd.NA
+
+    return ranked.loc[:, _RANKING_OUTPUT_COLUMNS]
+
+
+def write_comparison_ranking(
+    *,
+    comparison_dir: Path,
+    comparison_run_id: str,
+    generated_at: str,
+    comparison_metrics_csv_path: Path,
+) -> dict[str, Any]:
+    metrics_df = _load_comparison_metrics(comparison_metrics_csv_path)
+    ranked = build_comparison_ranking(metrics_df)
+
+    ranking_summary_path = Path(comparison_dir) / RANKING_SUMMARY_JSON_FILENAME
+    strategy_ranking_csv_path = Path(comparison_dir) / STRATEGY_RANKING_CSV_FILENAME
+    ranking_summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    ranked.to_csv(strategy_ranking_csv_path, index=False)
+
+    ranked_runs = ranked.where(pd.notna(ranked), None).to_dict(orient="records")
+    preferred_run = dict(ranked_runs[0])
+    payload = {
+        "comparison_run_id": comparison_run_id,
+        "generated_at": generated_at,
+        "selection_rule": _SELECTION_RULE,
+        "source_artifacts": {
+            "comparison_metrics_csv": Path(comparison_metrics_csv_path).name,
+            "strategy_ranking_csv": STRATEGY_RANKING_CSV_FILENAME,
+        },
+        "preferred_run": preferred_run,
+        "ranked_runs": ranked_runs,
+    }
+
+    with ranking_summary_path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+
+    return {
+        "ranking_summary_json_path": ranking_summary_path,
+        "strategy_ranking_csv_path": strategy_ranking_csv_path,
+        "preferred_run": preferred_run,
+    }

--- a/src/engine/comparison_runner.py
+++ b/src/engine/comparison_runner.py
@@ -13,6 +13,7 @@ from src.data.features import add_basic_features
 from src.data.loader import get_benchmark_symbol, load_market_data, load_yaml
 from src.engine.broker import Broker
 from src.engine.comparison_metrics import write_comparison_metrics
+from src.engine.comparison_ranking import write_comparison_ranking
 from src.engine.comparison_exports import write_aligned_equity_curves
 from src.engine.metrics import compute_backtest_metrics, write_metrics_json
 from src.engine.portfolio import Portfolio
@@ -452,6 +453,12 @@ def run_m3_comparison(
         created_at=created_at,
         runs=run_records,
     )
+    ranking_paths = write_comparison_ranking(
+        comparison_dir=comparison_dir,
+        comparison_run_id=comparison_run_id,
+        generated_at=created_at,
+        comparison_metrics_csv_path=comparison_metrics_paths["csv_path"],
+    )
     aligned_curve_paths = _write_aligned_curves(comparison_dir=comparison_dir, run_records=run_records)
 
     summary_payload = {
@@ -477,13 +484,18 @@ def run_m3_comparison(
             "aligned_equity_curves_csv_path": str(aligned_curve_paths["equity_path"]),
             "aligned_drawdowns_csv_path": str(aligned_curve_paths["drawdown_path"]),
             "comparison_metrics_json_path": str(comparison_metrics_paths["json_path"]),
+            "ranking_summary_json_path": str(ranking_paths["ranking_summary_json_path"]),
+            "strategy_ranking_csv_path": str(ranking_paths["strategy_ranking_csv_path"]),
         },
         "exports": {
             "comparison_metrics_json_path": "comparison_metrics.json",
             "comparison_metrics_csv_path": "comparison_metrics.csv",
             "aligned_equity_curves_csv": "aligned_equity_curves.csv",
             "aligned_drawdowns_csv": "aligned_drawdowns.csv",
+            "ranking_summary_json": "ranking_summary.json",
+            "strategy_ranking_csv": "strategy_ranking.csv",
         },
+        "preferred_run": ranking_paths["preferred_run"],
     }
     comparison_summary_path = _write_json(comparison_dir / COMPARISON_SUMMARY_FILENAME, summary_payload)
 
@@ -506,6 +518,9 @@ def run_m3_comparison(
         "aligned_drawdowns_csv_path": str(comparison_metrics_paths["aligned_drawdowns_csv_path"]),
         "comparison_summary_json_path": str(comparison_metrics_paths["comparison_summary_json_path"]),
         "comparison_summary_path": str(comparison_metrics_paths["comparison_summary_json_path"]),
+        "ranking_summary_json_path": str(ranking_paths["ranking_summary_json_path"]),
+        "strategy_ranking_csv_path": str(ranking_paths["strategy_ranking_csv_path"]),
+        "preferred_run": ranking_paths["preferred_run"],
         "runs": run_records,
         "compared_strategies": [item["name"] for item in run_records],
     }
@@ -527,6 +542,9 @@ def run_m3_comparison(
         "aligned_equity_curves_csv_path": comparison_metrics_paths["aligned_equity_curves_csv_path"],
         "aligned_drawdowns_csv_path": comparison_metrics_paths["aligned_drawdowns_csv_path"],
         "comparison_summary_json_path": comparison_metrics_paths["comparison_summary_json_path"],
+        "ranking_summary_json_path": ranking_paths["ranking_summary_json_path"],
+        "strategy_ranking_csv_path": ranking_paths["strategy_ranking_csv_path"],
+        "preferred_run": ranking_paths["preferred_run"],
         "runs": run_records,
     }
 

--- a/src/engine/test_comparison_ranking.py
+++ b/src/engine/test_comparison_ranking.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from src.engine.comparison_ranking import write_comparison_ranking
+
+
+def _metric_row(
+    *,
+    run_name: str,
+    run_id: str,
+    strategy_type: str = "momentum",
+    variant_name: str = "baseline",
+    sharpe_ratio: float = 0.0,
+    cumulative_return: float = 0.0,
+    max_drawdown: float = 0.0,
+) -> dict[str, object]:
+    return {
+        "run_name": run_name,
+        "run_id": run_id,
+        "strategy_type": strategy_type,
+        "variant_name": variant_name,
+        "sharpe_ratio": sharpe_ratio,
+        "cumulative_return": cumulative_return,
+        "max_drawdown": max_drawdown,
+        "return_over_max_drawdown": 0.0,
+        "volatility": 0.0,
+        "average_daily_return": 0.0,
+        "trade_count": 0,
+        "win_rate": None,
+        "activity_metrics_status": "computed",
+    }
+
+
+class ComparisonRankingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp_dir.name)
+        self.comparison_dir = self.tmp_path / "comparison"
+        self.comparison_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics_path = self.comparison_dir / "comparison_metrics.csv"
+
+    def tearDown(self) -> None:
+        self._tmp_dir.cleanup()
+
+    def _write_metrics(self, rows: list[dict[str, object]]) -> None:
+        pd.DataFrame(rows).to_csv(self.metrics_path, index=False)
+
+    def test_ranking_summary_orders_runs_and_marks_preferred_run(self) -> None:
+        self._write_metrics(
+            [
+                _metric_row(run_name="buy_and_hold", run_id="run-bh", strategy_type="baseline", variant_name="buy_and_hold", sharpe_ratio=0.6, cumulative_return=0.10, max_drawdown=-0.08),
+                _metric_row(run_name="momentum_fast", run_id="run-fast", sharpe_ratio=0.9, cumulative_return=0.14, max_drawdown=-0.07, variant_name="fast"),
+                _metric_row(run_name="equal_weight", run_id="run-ew", strategy_type="baseline", variant_name="equal_weight", sharpe_ratio=0.7, cumulative_return=0.12, max_drawdown=-0.06),
+            ]
+        )
+
+        result = write_comparison_ranking(
+            comparison_dir=self.comparison_dir,
+            comparison_run_id="cmp-001",
+            generated_at="2026-03-18T00:00:00+00:00",
+            comparison_metrics_csv_path=self.metrics_path,
+        )
+
+        self.assertTrue(result["ranking_summary_json_path"].exists())
+        self.assertTrue(result["strategy_ranking_csv_path"].exists())
+
+        summary = json.loads(result["ranking_summary_json_path"].read_text(encoding="utf-8"))
+        self.assertEqual(summary["comparison_run_id"], "cmp-001")
+        self.assertEqual(summary["preferred_run"]["run_name"], "momentum_fast")
+        self.assertEqual(summary["preferred_run"]["rank"], 1)
+        self.assertEqual(summary["selection_rule"]["primary_metric"]["name"], "sharpe_ratio")
+        self.assertEqual(
+            [item["run_name"] for item in summary["ranked_runs"]],
+            ["momentum_fast", "equal_weight", "buy_and_hold"],
+        )
+
+        ranking_df = pd.read_csv(result["strategy_ranking_csv_path"])
+        self.assertEqual(ranking_df["rank"].tolist(), [1, 2, 3])
+        self.assertEqual(ranking_df["run_name"].tolist(), ["momentum_fast", "equal_weight", "buy_and_hold"])
+
+    def test_single_run_is_ranked_and_selected(self) -> None:
+        self._write_metrics([_metric_row(run_name="momentum_baseline", run_id="run-1", sharpe_ratio=0.4, cumulative_return=0.08, max_drawdown=-0.03)])
+
+        result = write_comparison_ranking(
+            comparison_dir=self.comparison_dir,
+            comparison_run_id="cmp-001",
+            generated_at="2026-03-18T00:00:00+00:00",
+            comparison_metrics_csv_path=self.metrics_path,
+        )
+
+        summary = json.loads(result["ranking_summary_json_path"].read_text(encoding="utf-8"))
+        self.assertEqual(len(summary["ranked_runs"]), 1)
+        self.assertEqual(summary["preferred_run"]["run_name"], "momentum_baseline")
+        self.assertEqual(summary["preferred_run"]["rank"], 1)
+
+    def test_ties_are_resolved_by_cumulative_return_then_drawdown_then_run_name(self) -> None:
+        self._write_metrics(
+            [
+                _metric_row(run_name="momentum_beta", run_id="run-2", sharpe_ratio=1.0, cumulative_return=0.10, max_drawdown=-0.08),
+                _metric_row(run_name="momentum_alpha", run_id="run-1", sharpe_ratio=1.0, cumulative_return=0.10, max_drawdown=-0.08),
+                _metric_row(run_name="momentum_gamma", run_id="run-3", sharpe_ratio=1.0, cumulative_return=0.12, max_drawdown=-0.09),
+                _metric_row(run_name="momentum_delta", run_id="run-4", sharpe_ratio=1.0, cumulative_return=0.10, max_drawdown=-0.05),
+            ]
+        )
+
+        result = write_comparison_ranking(
+            comparison_dir=self.comparison_dir,
+            comparison_run_id="cmp-001",
+            generated_at="2026-03-18T00:00:00+00:00",
+            comparison_metrics_csv_path=self.metrics_path,
+        )
+
+        summary = json.loads(result["ranking_summary_json_path"].read_text(encoding="utf-8"))
+        self.assertEqual(
+            [item["run_name"] for item in summary["ranked_runs"]],
+            ["momentum_gamma", "momentum_delta", "momentum_alpha", "momentum_beta"],
+        )
+
+    def test_repeated_generation_is_identical_for_identical_inputs(self) -> None:
+        self._write_metrics(
+            [
+                _metric_row(run_name="equal_weight", run_id="run-ew", strategy_type="baseline", variant_name="equal_weight", sharpe_ratio=0.7, cumulative_return=0.12, max_drawdown=-0.06),
+                _metric_row(run_name="momentum_fast", run_id="run-fast", sharpe_ratio=0.9, cumulative_return=0.14, max_drawdown=-0.07, variant_name="fast"),
+            ]
+        )
+
+        first = write_comparison_ranking(
+            comparison_dir=self.comparison_dir,
+            comparison_run_id="cmp-001",
+            generated_at="2026-03-18T00:00:00+00:00",
+            comparison_metrics_csv_path=self.metrics_path,
+        )
+        first_summary = first["ranking_summary_json_path"].read_text(encoding="utf-8")
+        first_csv = first["strategy_ranking_csv_path"].read_text(encoding="utf-8")
+
+        second = write_comparison_ranking(
+            comparison_dir=self.comparison_dir,
+            comparison_run_id="cmp-001",
+            generated_at="2026-03-18T00:00:00+00:00",
+            comparison_metrics_csv_path=self.metrics_path,
+        )
+        second_summary = second["ranking_summary_json_path"].read_text(encoding="utf-8")
+        second_csv = second["strategy_ranking_csv_path"].read_text(encoding="utf-8")
+
+        self.assertEqual(first_summary, second_summary)
+        self.assertEqual(first_csv, second_csv)
+
+    def test_missing_comparison_metrics_file_fails_clearly(self) -> None:
+        missing_path = self.comparison_dir / "missing.csv"
+        with self.assertRaisesRegex(FileNotFoundError, "Missing comparison metrics input for ranking"):
+            write_comparison_ranking(
+                comparison_dir=self.comparison_dir,
+                comparison_run_id="cmp-001",
+                generated_at="2026-03-18T00:00:00+00:00",
+                comparison_metrics_csv_path=missing_path,
+            )
+
+    def test_missing_required_ranking_metrics_fail_clearly(self) -> None:
+        pd.DataFrame([{"run_name": "momentum_baseline", "run_id": "run-1"}]).to_csv(self.metrics_path, index=False)
+
+        with self.assertRaisesRegex(ValueError, "Ranking input is missing required columns"):
+            write_comparison_ranking(
+                comparison_dir=self.comparison_dir,
+                comparison_run_id="cmp-001",
+                generated_at="2026-03-18T00:00:00+00:00",
+                comparison_metrics_csv_path=self.metrics_path,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/engine/test_comparison_runner.py
+++ b/src/engine/test_comparison_runner.py
@@ -286,10 +286,42 @@ baselines:
             "aligned_equity_curves_csv_path": comparison_dir / "aligned_equity_curves.csv",
             "aligned_drawdowns_csv_path": comparison_dir / "aligned_drawdowns.csv",
             "comparison_summary_json_path": comparison_dir / "comparison_summary.json",
+            "ranking_summary_json_path": comparison_dir / "ranking_summary.json",
+            "strategy_ranking_csv_path": comparison_dir / "strategy_ranking.csv",
         }
         for key, expected_path in expected_paths.items():
             self.assertEqual(result[key], expected_path)
             self.assertTrue(expected_path.exists())
+
+    def test_ranking_summary_artifact_identifies_preferred_run(self) -> None:
+        self._write_config()
+        result = run_m3_comparison(config_path=self.config_path, output_root=self.output_dir)
+
+        ranking_summary = json.loads(result["ranking_summary_json_path"].read_text(encoding="utf-8"))
+        ranking_csv = pd.read_csv(result["strategy_ranking_csv_path"])
+        manifest = json.loads(result["comparison_manifest_path"].read_text(encoding="utf-8"))
+        summary = json.loads(result["comparison_summary_path"].read_text(encoding="utf-8"))
+
+        self.assertEqual(ranking_summary["comparison_run_id"], result["comparison_run_id"])
+        self.assertEqual(ranking_summary["preferred_run"]["rank"], 1)
+        self.assertEqual(ranking_summary["preferred_run"]["run_name"], ranking_csv.iloc[0]["run_name"])
+        self.assertEqual(ranking_csv["rank"].tolist(), list(range(1, len(ranking_csv) + 1)))
+        self.assertEqual(
+            [item["run_name"] for item in ranking_summary["ranked_runs"]],
+            ranking_csv["run_name"].tolist(),
+        )
+        self.assertEqual(summary["preferred_run"]["run_name"], ranking_summary["preferred_run"]["run_name"])
+        self.assertEqual(
+            summary["artifacts"]["ranking_summary_json_path"],
+            str(result["ranking_summary_json_path"]),
+        )
+        self.assertEqual(
+            summary["artifacts"]["strategy_ranking_csv_path"],
+            str(result["strategy_ranking_csv_path"]),
+        )
+        self.assertEqual(manifest["ranking_summary_json_path"], str(result["ranking_summary_json_path"]))
+        self.assertEqual(manifest["strategy_ranking_csv_path"], str(result["strategy_ranking_csv_path"]))
+        self.assertEqual(manifest["preferred_run"]["run_name"], ranking_summary["preferred_run"]["run_name"])
 
     def test_repeated_runs_preserve_export_schema_and_column_ordering(self) -> None:
         self._write_config()


### PR DESCRIPTION
Closes #51

## What changed
- added a ranking summary layer for M3 compared strategies
- ranked the main strategy, baselines, and parameter variants using shared comparison metrics
- defined a simple and transparent selection rule
- saved a ranking summary artifact with the preferred configuration
- made the final M3 decision output easy to reference later

## Why
This PR adds a lightweight decision layer so M3 results can identify which strategy or baseline configuration should be carried forward instead of leaving interpretation fully manual.

## Notes
The ranking logic is intentionally simple, repeatable, and focused on roadmap usability rather than complex optimization.