### PR TITLE
feat(strategy): compare ML outputs against rule-based strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The official M4 target contract, modeling dataset export, preparation pipeline, 
 - `docs/m4_baseline_evaluation_reports.md`
 - `docs/m4_batch_prediction_pipeline.md`
 - `docs/m4_model_output_logging.md`
+- `docs/m4_ml_vs_rule_comparison.md`
 
 Prepare the modeling dataset from the reusable processed feature parquet with:
 
@@ -103,4 +104,10 @@ Generate reusable batch predictions from a trained M4 baseline run with:
 
 ```bash
 python -m src.engine.generate_predictions --training-summary outputs/models/<training_run_id>/baseline_training_summary.json
+```
+
+Compare a logged M4 prediction run against the current rule-based momentum strategy with:
+
+```bash
+python -m src.engine.compare_ml_vs_rule --predictions outputs/predictions/model_batches/<prediction_run_id>/baseline_model_predictions.parquet
 ```

--- a/config/evaluation/m4_ml_vs_rule_comparison.yaml
+++ b/config/evaluation/m4_ml_vs_rule_comparison.yaml
@@ -1,0 +1,14 @@
+comparison:
+  milestone: M4
+  contract_name: m4_official_ml_vs_rule_comparison
+  version: 1
+  training_config_path: config/modeling/m4_baselines.yaml
+  prediction_config_path: config/evaluation/m4_batch_prediction.yaml
+  prediction_log_config_path: config/modeling/m4_prediction_logs.yaml
+  strategy_config_path: config/settings.yaml
+  feature_dataset_path: data/processed/market_features.parquet
+  output_dir: outputs/reports/ml_vs_rule_comparisons
+  strategy_name: M4MLVsRuleComparison
+  run_label: m4-ml-vs-rule-comparison
+  methodology_name: validation_signal_alignment
+  comparison_signal_column: rule_entry_signal

--- a/docs/m4_ml_vs_rule_comparison.md
+++ b/docs/m4_ml_vs_rule_comparison.md
@@ -1,0 +1,68 @@
+# M4 ML-vs-Rule Comparison
+
+The M4 ML-vs-rule workflow compares the logged baseline model predictions against the current rule-based momentum strategy under one explicit, reproducible methodology.
+
+## Official inputs
+
+- prediction log artifact: `outputs/predictions/model_batches/<prediction_run_id>/baseline_model_predictions.parquet`
+- prediction log metadata: `outputs/predictions/model_batches/<prediction_run_id>/baseline_model_predictions.metadata.json`
+- training summary artifact referenced by the prediction metadata
+- shared feature dataset for rule replay: `data/processed/market_features.parquet`
+- current rule-strategy settings: `config/settings.yaml`
+- comparison config: `config/evaluation/m4_ml_vs_rule_comparison.yaml`
+
+## Methodology
+
+The official methodology is `validation_signal_alignment`.
+
+It works in five steps:
+
+1. reload the official M4 prediction log and rebuild the same validation split used to generate those prediction rows
+2. replay the live momentum strategy through the existing simulator on the shared feature history for the comparison symbols through the validation end date
+3. align both sides on the shared row keys `symbol`, `date`, and `target_date`
+4. keep the raw rule action as `BUY`, `SELL`, or `HOLD`, while mapping the common binary comparison label to `rule_entry_signal = 1` only for `BUY`
+5. export row-level aligned artifacts plus small summary tables that show agreement, disagreement, and next-session outcome context
+
+This keeps the comparison time-safe because:
+
+- ML rows keep the official `date -> target_date` forward-looking contract
+- rule decisions come from the existing simulator path that only exposes data up to the decision date
+- the simulator still strips `target_` columns before strategy execution
+- the replay still uses next-session execution behavior
+
+## Why the mapping is explicit
+
+The baseline M4 models predict next-session direction, not a full portfolio action. The current rule strategy emits `BUY`, `SELL`, or no action depending on portfolio state.
+
+To keep the first comparison interpretable:
+
+- raw rule actions are preserved in the aligned artifact
+- the common binary label is `BUY = 1`, `SELL/HOLD = 0`
+
+That makes the first comparison about entry alignment while still exposing rule exits for later simulation integration work.
+
+## Run command
+
+```bash
+python -m src.engine.compare_ml_vs_rule --predictions outputs/predictions/model_batches/<prediction_run_id>/baseline_model_predictions.parquet
+```
+
+## Output contract
+
+Each comparison run writes a self-contained directory under `outputs/reports/ml_vs_rule_comparisons/<comparison_run_id>/` with:
+
+- `config.json`
+- `manifest.json`
+- `ml_vs_rule_aligned.parquet`
+- `ml_vs_rule_aligned.metadata.json`
+- `ml_vs_rule_summary.json`
+- `ml_vs_rule_summary.csv`
+- `ml_vs_rule_by_symbol.csv`
+- `rule_strategy_runs/` containing the replayed rule-strategy run artifacts
+
+## How to read the results
+
+- `ml_vs_rule_aligned.parquet` is the canonical row-level artifact for later reuse
+- `ml_vs_rule_summary.csv` shows one row per model with agreement counts, rule-action rates, and disagreement outcome context
+- `ml_vs_rule_by_symbol.csv` highlights where the model and the rule differ most by asset
+- `rule_strategy_runs/` keeps the replayed rule-strategy evidence bundle for later simulation-level follow-up

--- a/src/engine/compare_ml_vs_rule.py
+++ b/src/engine/compare_ml_vs_rule.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.engine.ml_vs_rule_comparison import (
+    M4_ML_VS_RULE_COMPARISON_CONFIG_PATH,
+    run_m4_ml_vs_rule_comparison,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compare official M4 model outputs against the rule-based momentum strategy.")
+    parser.add_argument(
+        "--predictions",
+        required=True,
+        help="Path to a baseline_model_predictions.parquet artifact produced by the M4 batch prediction pipeline.",
+    )
+    parser.add_argument(
+        "--metadata",
+        help="Optional path to the baseline_model_predictions.metadata.json sidecar. Defaults to the official sibling filename.",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(M4_ML_VS_RULE_COMPARISON_CONFIG_PATH),
+        help="Path to the official M4 ML-vs-rule comparison config YAML.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_m4_ml_vs_rule_comparison(
+            predictions_path=Path(args.predictions),
+            metadata_path=Path(args.metadata) if args.metadata else None,
+            config_path=Path(args.config),
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"[ERROR] ML-vs-rule comparison failed unexpectedly: {exc}", file=sys.stderr)
+        return 1
+
+    print("-" * 60)
+    print("M4 ML-vs-rule comparison completed")
+    print(f"Run id: {result['run_id']}")
+    print(f"Output directory: {result['output_dir']}")
+    print(f"Manifest: {result['manifest_path']}")
+    print(f"Aligned comparison: {result['aligned_path']}")
+    print(f"Summary JSON: {result['summary_json_path']}")
+    print(f"Summary CSV: {result['summary_csv_path']}")
+    print(f"Per-symbol summary CSV: {result['per_symbol_summary_csv_path']}")
+    print(f"Rule replay manifest: {result['rule_replay_manifest_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/engine/ml_vs_rule_comparison.py
+++ b/src/engine/ml_vs_rule_comparison.py
@@ -1,0 +1,1064 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.data.loader import load_yaml
+from src.data.prediction_logs import (
+    load_m4_prediction_log_bundle,
+    load_m4_prediction_log_definition,
+)
+from src.engine.broker import Broker
+from src.engine.model_evaluation import load_m4_baseline_training_run_bundle
+from src.engine.portfolio import Portfolio
+from src.engine.run_artifacts import RunArtifactManager
+from src.engine.simulator import DailySimulator
+from src.strategy.ml_baselines import build_dataframe_signature, prepare_m4_baseline_training_data
+from src.strategy.momentum import MomentumStrategy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+M4_ML_VS_RULE_COMPARISON_CONFIG_PATH = REPO_ROOT / "config" / "evaluation" / "m4_ml_vs_rule_comparison.yaml"
+ALIGNED_COMPARISON_FILENAME = "ml_vs_rule_aligned.parquet"
+ALIGNED_COMPARISON_METADATA_FILENAME = "ml_vs_rule_aligned.metadata.json"
+COMPARISON_SUMMARY_JSON_FILENAME = "ml_vs_rule_summary.json"
+COMPARISON_SUMMARY_CSV_FILENAME = "ml_vs_rule_summary.csv"
+PER_SYMBOL_SUMMARY_CSV_FILENAME = "ml_vs_rule_by_symbol.csv"
+RULE_REPLAY_RUNS_DIRNAME = "rule_strategy_runs"
+PIPELINE_VERSION = 1
+ENTRYPOINT = "python -m src.engine.compare_ml_vs_rule"
+COMPARISON_KEY_COLUMNS = ["symbol", "date", "target_date"]
+ALIGNED_SORT_ORDER = ["model_name", "symbol", "date", "target_date"]
+SUMMARY_ROW_COLUMNS = [
+    "model_name",
+    "estimator",
+    "prediction_run_id",
+    "training_run_id",
+    "row_count",
+    "symbol_count",
+    "agreement_rate",
+    "disagreement_rate",
+    "shared_entry_count",
+    "ml_only_entry_count",
+    "rule_only_entry_count",
+    "shared_non_entry_count",
+    "rule_buy_count",
+    "rule_sell_count",
+    "rule_hold_count",
+    "model_positive_rate",
+    "rule_buy_rate",
+    "rule_sell_rate",
+    "rule_hold_rate",
+    "actual_positive_rate",
+    "ml_accuracy_vs_actual",
+    "rule_entry_accuracy_vs_actual",
+    "actual_positive_rate_both_entry",
+    "actual_positive_rate_ml_only_entry",
+    "actual_positive_rate_rule_only_entry",
+    "actual_positive_rate_shared_non_entry",
+    "mean_predicted_probability",
+    "mean_predicted_probability_rule_buy",
+    "mean_predicted_probability_rule_sell",
+    "mean_predicted_probability_rule_hold",
+]
+PER_SYMBOL_SUMMARY_COLUMNS = [
+    "model_name",
+    "symbol",
+    "row_count",
+    "agreement_rate",
+    "shared_entry_count",
+    "ml_only_entry_count",
+    "rule_only_entry_count",
+    "shared_non_entry_count",
+    "rule_buy_count",
+    "rule_sell_count",
+    "rule_hold_count",
+    "actual_positive_rate",
+    "ml_accuracy_vs_actual",
+    "rule_entry_accuracy_vs_actual",
+    "mean_predicted_probability",
+]
+ALIGNED_COMPARISON_COLUMNS = [
+    "prediction_run_id",
+    "training_run_id",
+    "inference_partition",
+    "model_name",
+    "estimator",
+    "model_artifact_path",
+    "model_metadata_path",
+    "symbol",
+    "date",
+    "target_date",
+    "target_column",
+    "task_type",
+    "predicted_class",
+    "predicted_probability",
+    "actual_target",
+    "actual_target_return",
+    "rule_action",
+    "rule_reason_code",
+    "rule_score",
+    "rule_target_weight",
+    "rule_schedule_status",
+    "rule_scheduled_execution_date",
+    "rule_entry_signal",
+    "rule_exit_signal",
+    "comparison_outcome",
+    "is_agreement",
+    "is_disagreement",
+    "ml_matches_actual_target",
+    "rule_entry_matches_actual_target",
+    "probability_distance_from_threshold",
+]
+
+
+@dataclass(frozen=True)
+class OfficialM4MLVsRuleComparisonDefinition:
+    milestone: str
+    contract_name: str
+    version: int
+    training_config_path: str
+    prediction_config_path: str
+    prediction_log_config_path: str
+    strategy_config_path: str
+    feature_dataset_path: str
+    output_dir: str
+    strategy_name: str
+    run_label: str
+    methodology_name: str
+    comparison_signal_column: str
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (datetime, pd.Timestamp)):
+        return pd.Timestamp(value).isoformat()
+    return value
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(_jsonable(payload), fh, indent=2, sort_keys=True)
+    return path
+
+
+def _resolve_repo_path(value: str | Path) -> Path:
+    path = Path(str(value).strip())
+    if not str(path):
+        raise ValueError("Configured path value cannot be empty.")
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _format_date(value: Any) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    return pd.Timestamp(value).strftime("%Y-%m-%d")
+
+
+def _normalize_datetime_series(series: pd.Series) -> pd.Series:
+    normalized = pd.to_datetime(series, errors="coerce")
+    if getattr(normalized.dt, "tz", None) is not None:
+        normalized = normalized.dt.tz_localize(None)
+    return normalized.astype("datetime64[ns]")
+
+
+def _normalize_symbol_series(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.upper().str.strip()
+
+
+def _validate_binary_series(values: pd.Series, *, label: str) -> pd.Series:
+    numeric_values = pd.to_numeric(values, errors="coerce")
+    if numeric_values.isna().any():
+        raise ValueError(f"Comparison requires '{label}' to contain only numeric 0/1 values.")
+    if not bool((numeric_values == numeric_values.round()).all()):
+        raise ValueError(f"Comparison requires '{label}' to contain exact integer 0/1 values.")
+    normalized = numeric_values.astype("int64")
+    if not set(normalized.tolist()).issubset({0, 1}):
+        raise ValueError(f"Comparison requires '{label}' to contain only 0/1 values.")
+    return normalized
+
+
+def _mean_or_none(series: pd.Series) -> float | None:
+    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric.empty:
+        return None
+    return float(numeric.mean())
+
+
+def _comparison_outcome(row: pd.Series) -> str:
+    if int(row["predicted_class"]) == 1 and int(row["rule_entry_signal"]) == 1:
+        return "both_entry"
+    if int(row["predicted_class"]) == 1 and int(row["rule_entry_signal"]) == 0:
+        return "ml_only_entry"
+    if int(row["predicted_class"]) == 0 and int(row["rule_entry_signal"]) == 1:
+        return "rule_only_entry"
+    return "shared_non_entry"
+
+
+def load_m4_ml_vs_rule_comparison_definition(
+    config_path: Path = M4_ML_VS_RULE_COMPARISON_CONFIG_PATH,
+) -> OfficialM4MLVsRuleComparisonDefinition:
+    data = load_yaml(config_path)
+    comparison_cfg = data.get("comparison")
+    if not isinstance(comparison_cfg, dict):
+        raise ValueError(f"Missing or invalid comparison config in: {config_path}")
+
+    definition = OfficialM4MLVsRuleComparisonDefinition(
+        milestone=str(comparison_cfg.get("milestone", "")).strip(),
+        contract_name=str(comparison_cfg.get("contract_name", "")).strip(),
+        version=int(comparison_cfg.get("version", 0) or 0),
+        training_config_path=str(comparison_cfg.get("training_config_path", "")).strip(),
+        prediction_config_path=str(comparison_cfg.get("prediction_config_path", "")).strip(),
+        prediction_log_config_path=str(comparison_cfg.get("prediction_log_config_path", "")).strip(),
+        strategy_config_path=str(comparison_cfg.get("strategy_config_path", "")).strip(),
+        feature_dataset_path=str(comparison_cfg.get("feature_dataset_path", "")).strip(),
+        output_dir=str(comparison_cfg.get("output_dir", "")).strip(),
+        strategy_name=str(comparison_cfg.get("strategy_name", "")).strip(),
+        run_label=str(comparison_cfg.get("run_label", "")).strip(),
+        methodology_name=str(comparison_cfg.get("methodology_name", "")).strip(),
+        comparison_signal_column=str(comparison_cfg.get("comparison_signal_column", "")).strip(),
+    )
+
+    if definition.milestone != "M4":
+        raise ValueError("Official M4 ML-vs-rule comparison milestone must be 'M4'.")
+    if not definition.contract_name:
+        raise ValueError("Official M4 ML-vs-rule comparison contract_name is required.")
+    if definition.version < 1:
+        raise ValueError("Official M4 ML-vs-rule comparison version must be >= 1.")
+    if definition.training_config_path != "config/modeling/m4_baselines.yaml":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison training_config_path must be "
+            "'config/modeling/m4_baselines.yaml'."
+        )
+    if definition.prediction_config_path != "config/evaluation/m4_batch_prediction.yaml":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison prediction_config_path must be "
+            "'config/evaluation/m4_batch_prediction.yaml'."
+        )
+    if definition.prediction_log_config_path != "config/modeling/m4_prediction_logs.yaml":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison prediction_log_config_path must be "
+            "'config/modeling/m4_prediction_logs.yaml'."
+        )
+    if definition.strategy_config_path != "config/settings.yaml":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison strategy_config_path must be 'config/settings.yaml'."
+        )
+    if definition.feature_dataset_path != "data/processed/market_features.parquet":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison feature_dataset_path must be "
+            "'data/processed/market_features.parquet'."
+        )
+    if definition.output_dir != "outputs/reports/ml_vs_rule_comparisons":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison output_dir must be "
+            "'outputs/reports/ml_vs_rule_comparisons'."
+        )
+    if not definition.strategy_name:
+        raise ValueError("Official M4 ML-vs-rule comparison strategy_name is required.")
+    if not definition.run_label:
+        raise ValueError("Official M4 ML-vs-rule comparison run_label is required.")
+    if definition.methodology_name != "validation_signal_alignment":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison methodology_name must be "
+            "'validation_signal_alignment'."
+        )
+    if definition.comparison_signal_column != "rule_entry_signal":
+        raise ValueError(
+            "Official M4 ML-vs-rule comparison comparison_signal_column must be 'rule_entry_signal'."
+        )
+
+    return definition
+
+
+def _build_validation_rows(
+    validation_df: pd.DataFrame,
+    *,
+    actual_target_column: str,
+    actual_return_column: str,
+) -> pd.DataFrame:
+    required_columns = ["symbol", "date", "target_date", actual_target_column, actual_return_column]
+    missing_columns = [column for column in required_columns if column not in validation_df.columns]
+    if missing_columns:
+        raise ValueError(
+            "Validation dataframe is missing required comparison columns: " + ", ".join(missing_columns)
+        )
+
+    rows = validation_df.loc[:, required_columns].copy()
+    rows["symbol"] = _normalize_symbol_series(rows["symbol"])
+    rows["date"] = _normalize_datetime_series(rows["date"])
+    rows["target_date"] = _normalize_datetime_series(rows["target_date"])
+    if rows["date"].isna().any() or rows["target_date"].isna().any():
+        raise ValueError("Validation dataframe contains invalid comparison timestamps.")
+    if not bool((rows["target_date"] > rows["date"]).all()):
+        raise ValueError("Validation dataframe contains non-forward target timestamps.")
+
+    duplicate_feature_keys = rows.duplicated(subset=["symbol", "date"])
+    if duplicate_feature_keys.any():
+        raise ValueError("Validation dataframe contains duplicate symbol/date rows.")
+    duplicate_alignment_keys = rows.duplicated(subset=COMPARISON_KEY_COLUMNS)
+    if duplicate_alignment_keys.any():
+        raise ValueError("Validation dataframe contains duplicate symbol/date/target_date rows.")
+
+    rows["actual_target"] = _validate_binary_series(rows[actual_target_column], label=actual_target_column)
+    rows["actual_target_return"] = pd.to_numeric(rows[actual_return_column], errors="coerce").astype("Float64")
+
+    rows = rows.sort_values(COMPARISON_KEY_COLUMNS).reset_index(drop=True)
+    return rows.loc[:, ["symbol", "date", "target_date", "actual_target", "actual_target_return"]]
+
+
+def _validate_prediction_rows(
+    prediction_df: pd.DataFrame,
+    *,
+    validation_rows: pd.DataFrame,
+    expected_target_column: str,
+    expected_task_type: str,
+) -> None:
+    if prediction_df.empty:
+        raise ValueError("Prediction log produced no comparison rows.")
+    if prediction_df["prediction_run_id"].nunique(dropna=False) != 1:
+        raise ValueError("Comparison requires prediction rows from a single prediction_run_id.")
+    if prediction_df["training_run_id"].nunique(dropna=False) != 1:
+        raise ValueError("Comparison requires prediction rows from a single training_run_id.")
+    if prediction_df["inference_partition"].nunique(dropna=False) != 1:
+        raise ValueError("Comparison requires prediction rows from a single inference partition.")
+    if prediction_df["inference_partition"].iloc[0] != "validation":
+        raise ValueError("Comparison requires validation prediction rows.")
+
+    observed_target_columns = sorted(prediction_df["target_column"].dropna().astype(str).str.strip().unique().tolist())
+    if observed_target_columns != [expected_target_column]:
+        raise ValueError("Prediction log target_column does not match the official M4 comparison target.")
+    observed_task_types = (
+        prediction_df["task_type"].dropna().astype(str).str.strip().str.lower().unique().tolist()
+    )
+    if observed_task_types != [expected_task_type]:
+        raise ValueError("Prediction log task_type does not match the official M4 comparison task.")
+
+    expected_keys = validation_rows.loc[:, COMPARISON_KEY_COLUMNS].reset_index(drop=True).copy()
+    expected_keys["date"] = _normalize_datetime_series(expected_keys["date"])
+    expected_keys["target_date"] = _normalize_datetime_series(expected_keys["target_date"])
+    expected_index = pd.MultiIndex.from_frame(expected_keys)
+    expected_row_count = len(expected_keys)
+
+    for model_name, model_rows in prediction_df.groupby("model_name", sort=True):
+        observed_keys = model_rows.loc[:, COMPARISON_KEY_COLUMNS].reset_index(drop=True).copy()
+        observed_keys["date"] = _normalize_datetime_series(observed_keys["date"])
+        observed_keys["target_date"] = _normalize_datetime_series(observed_keys["target_date"])
+        if len(observed_keys) != expected_row_count:
+            raise ValueError(
+                f"Prediction rows for model '{model_name}' do not match the official validation row count."
+            )
+
+        observed_index = pd.MultiIndex.from_frame(observed_keys)
+        missing_keys = expected_index.difference(observed_index)
+        extra_keys = observed_index.difference(expected_index)
+        if len(missing_keys) or len(extra_keys):
+            details: list[str] = []
+            if len(missing_keys):
+                details.append(f"missing_keys={len(missing_keys)}")
+            if len(extra_keys):
+                details.append(f"extra_keys={len(extra_keys)}")
+            raise ValueError(
+                f"Prediction rows for model '{model_name}' do not match official validation keys. "
+                + ", ".join(details)
+            )
+
+        if not observed_keys.equals(expected_keys):
+            raise ValueError(
+                f"Prediction rows for model '{model_name}' are not sorted by the official validation key order."
+            )
+
+
+def _load_rule_settings(strategy_config_path: Path) -> dict[str, Any]:
+    settings = load_yaml(strategy_config_path)
+    if not isinstance(settings, dict):
+        raise ValueError(f"Rule strategy config must be a mapping: {strategy_config_path}")
+    for section in ("strategy", "portfolio", "execution"):
+        if not isinstance(settings.get(section), dict):
+            raise ValueError(f"Rule strategy config is missing required '{section}' section: {strategy_config_path}")
+    return settings
+
+
+def _load_rule_feature_history(
+    *,
+    feature_dataset_path: Path,
+    comparison_symbols: list[str],
+    validation_rows: pd.DataFrame,
+) -> pd.DataFrame:
+    if not feature_dataset_path.exists():
+        raise FileNotFoundError(f"Missing rule feature dataset: {feature_dataset_path}")
+
+    feature_df = pd.read_parquet(feature_dataset_path)
+    if feature_df.empty:
+        raise ValueError("Rule feature dataset is empty.")
+
+    required_columns = {
+        "date",
+        "symbol",
+        "adj_close",
+        "ret_5d",
+        "ma_20",
+        "ma_50",
+        "price_vs_ma20",
+        "ma20_vs_ma50",
+        "volume_ratio_20",
+    }
+    missing_columns = required_columns - set(feature_df.columns)
+    if missing_columns:
+        raise ValueError(
+            "Rule feature dataset is missing required columns: " + ", ".join(sorted(missing_columns))
+        )
+
+    filtered = feature_df.copy()
+    filtered["date"] = _normalize_datetime_series(filtered["date"])
+    filtered["symbol"] = _normalize_symbol_series(filtered["symbol"])
+    if filtered["date"].isna().any():
+        raise ValueError("Rule feature dataset contains invalid dates.")
+
+    symbol_set = set(comparison_symbols)
+    validation_end_date = pd.Timestamp(validation_rows["date"].max())
+    filtered = filtered.loc[
+        filtered["symbol"].isin(symbol_set) & (filtered["date"] <= validation_end_date)
+    ].copy()
+    if filtered.empty:
+        raise ValueError("Rule feature dataset has no rows for the comparison symbols and date window.")
+
+    duplicate_keys = filtered.duplicated(subset=["symbol", "date"])
+    if duplicate_keys.any():
+        raise ValueError("Rule feature dataset contains duplicate symbol/date rows.")
+
+    expected_feature_keys = validation_rows.loc[:, ["symbol", "date"]].drop_duplicates().reset_index(drop=True)
+    expected_index = pd.MultiIndex.from_frame(expected_feature_keys)
+    observed_index = pd.MultiIndex.from_frame(filtered.loc[:, ["symbol", "date"]])
+    missing_validation_keys = expected_index.difference(observed_index)
+    if len(missing_validation_keys):
+        raise ValueError("Rule feature dataset is missing validation rows required for comparison.")
+
+    filtered = filtered.sort_values(["date", "symbol"]).reset_index(drop=True)
+    return filtered
+
+
+def _run_rule_strategy_replay(
+    *,
+    feature_history: pd.DataFrame,
+    settings: dict[str, Any],
+    comparison_run_id: str,
+    comparison_dir: Path,
+    config_source: Path,
+) -> dict[str, Any]:
+    strategy_cfg = settings.get("strategy", {})
+    portfolio_cfg = settings.get("portfolio", {})
+    execution_cfg = settings.get("execution", {})
+    benchmark_cfg = settings.get("benchmark", {})
+
+    portfolio = Portfolio(initial_cash=float(portfolio_cfg.get("initial_cash", 0.0)))
+    broker = Broker(
+        commission_rate=float(execution_cfg.get("commission_rate", 0.0)),
+        slippage_rate=float(execution_cfg.get("slippage_rate", 0.0)),
+        fractional_shares=bool(portfolio_cfg.get("fractional_shares", True)),
+    )
+    strategy = MomentumStrategy(
+        max_open_positions=int(portfolio_cfg.get("max_open_positions", 1)),
+        top_k=int(strategy_cfg.get("top_k", 1)),
+        min_score=float(strategy_cfg.get("min_score", 0.0)),
+        min_volume_ratio=float(strategy_cfg.get("min_volume_ratio", 0.8)),
+    )
+    benchmark_symbol = str(benchmark_cfg.get("benchmark_symbol", "")).strip().upper()
+    comparison_symbols = sorted(feature_history["symbol"].dropna().astype(str).str.upper().unique().tolist())
+
+    simulator = DailySimulator(
+        market_data=feature_history,
+        strategy=strategy,
+        portfolio=portfolio,
+        broker=broker,
+        price_column="adj_close",
+    )
+
+    rule_runs_dir = comparison_dir / RULE_REPLAY_RUNS_DIRNAME
+    rule_runs_dir.mkdir(parents=True, exist_ok=True)
+
+    run_config = {
+        "strategy_name": "momentum_v0",
+        "strategy_parameters": {
+            "max_open_positions": strategy.max_open_positions,
+            "top_k": strategy.top_k,
+            "min_score": strategy.min_score,
+            "min_volume_ratio": strategy.min_volume_ratio,
+        },
+        "broker": {
+            "commission_rate": float(broker.commission_rate),
+            "slippage_rate": float(broker.slippage_rate),
+            "fractional_shares": bool(broker.fractional_shares),
+        },
+        "portfolio": {
+            "initial_cash": float(portfolio.initial_cash),
+            "max_open_positions": int(portfolio_cfg.get("max_open_positions", 1)),
+        },
+        "comparison": {
+            "entrypoint": "src.engine.compare_ml_vs_rule",
+            "comparison_run_id": comparison_run_id,
+        },
+        "strategy_variant": {"name": "rule_replay", "params": dict(strategy_cfg)},
+    }
+
+    import src.engine.simulator as simulator_module
+
+    original_backtests_dir = simulator_module.BACKTEST_OUTPUTS_DIR
+    simulator_module.BACKTEST_OUTPUTS_DIR = rule_runs_dir
+    try:
+        result = simulator.run(
+            start_date=feature_history["date"].min(),
+            end_date=feature_history["date"].max(),
+            benchmark_symbol=benchmark_symbol,
+            equal_weight_universe=comparison_symbols,
+            run_config=run_config,
+            config_source=str(config_source),
+            run_label="rule_strategy_replay",
+        )
+    finally:
+        simulator_module.BACKTEST_OUTPUTS_DIR = original_backtests_dir
+
+    return result
+
+
+def _build_rule_signal_rows(
+    *,
+    signal_history: pd.DataFrame,
+    validation_rows: pd.DataFrame,
+) -> pd.DataFrame:
+    if signal_history.empty:
+        normalized_signals = pd.DataFrame(
+            columns=[
+                "symbol",
+                "date",
+                "rule_action",
+                "rule_reason_code",
+                "rule_score",
+                "rule_target_weight",
+                "rule_schedule_status",
+                "rule_scheduled_execution_date",
+            ]
+        )
+    else:
+        required_columns = {"date", "symbol", "action"}
+        missing_columns = required_columns - set(signal_history.columns)
+        if missing_columns:
+            raise ValueError(
+                "Rule strategy replay is missing required signal columns: " + ", ".join(sorted(missing_columns))
+            )
+
+        normalized_signals = signal_history.copy()
+        normalized_signals["date"] = _normalize_datetime_series(normalized_signals["date"])
+        normalized_signals["symbol"] = _normalize_symbol_series(normalized_signals["symbol"])
+        if normalized_signals["date"].isna().any():
+            raise ValueError("Rule strategy replay contains invalid signal dates.")
+        if normalized_signals["symbol"].eq("").any():
+            raise ValueError("Rule strategy replay contains invalid empty symbols.")
+
+        duplicate_keys = normalized_signals.duplicated(subset=["symbol", "date"])
+        if duplicate_keys.any():
+            raise ValueError("Rule strategy replay produced duplicate symbol/date signals.")
+
+        normalized_signals["rule_action"] = normalized_signals["action"].astype(str).str.upper().str.strip()
+        invalid_actions = sorted(set(normalized_signals["rule_action"]) - {"BUY", "SELL", "HOLD"})
+        if invalid_actions:
+            raise ValueError("Rule strategy replay produced unsupported actions: " + ", ".join(invalid_actions))
+
+        normalized_signals["rule_reason_code"] = (
+            normalized_signals["reason_code"].fillna("").astype(str).str.strip()
+            if "reason_code" in normalized_signals.columns
+            else ""
+        )
+        normalized_signals["rule_score"] = (
+            pd.to_numeric(normalized_signals["score"], errors="coerce").astype("Float64")
+            if "score" in normalized_signals.columns
+            else pd.Series(pd.NA, index=normalized_signals.index, dtype="Float64")
+        )
+        normalized_signals["rule_target_weight"] = (
+            pd.to_numeric(normalized_signals["target_weight"], errors="coerce").astype("Float64")
+            if "target_weight" in normalized_signals.columns
+            else pd.Series(pd.NA, index=normalized_signals.index, dtype="Float64")
+        )
+        normalized_signals["rule_schedule_status"] = (
+            normalized_signals["schedule_status"].fillna("").astype(str).str.strip()
+            if "schedule_status" in normalized_signals.columns
+            else ""
+        )
+        normalized_signals["rule_scheduled_execution_date"] = (
+            _normalize_datetime_series(normalized_signals["scheduled_execution_date"])
+            if "scheduled_execution_date" in normalized_signals.columns
+            else pd.Series(pd.NaT, index=normalized_signals.index, dtype="datetime64[ns]")
+        )
+
+        normalized_signals = normalized_signals.loc[
+            :,
+            [
+                "symbol",
+                "date",
+                "rule_action",
+                "rule_reason_code",
+                "rule_score",
+                "rule_target_weight",
+                "rule_schedule_status",
+                "rule_scheduled_execution_date",
+            ],
+        ]
+
+    rule_rows = validation_rows.loc[:, COMPARISON_KEY_COLUMNS].copy()
+    rule_rows = rule_rows.merge(normalized_signals, on=["symbol", "date"], how="left", validate="one_to_one")
+    rule_rows["rule_action"] = rule_rows["rule_action"].fillna("HOLD")
+    rule_rows["rule_reason_code"] = rule_rows["rule_reason_code"].fillna("")
+    rule_rows["rule_schedule_status"] = rule_rows["rule_schedule_status"].fillna("NO_SIGNAL")
+    rule_rows["rule_entry_signal"] = (rule_rows["rule_action"] == "BUY").astype("int64")
+    rule_rows["rule_exit_signal"] = (rule_rows["rule_action"] == "SELL").astype("int64")
+    rule_rows = rule_rows.sort_values(COMPARISON_KEY_COLUMNS).reset_index(drop=True)
+    return rule_rows
+
+
+def _build_aligned_comparison_table(
+    *,
+    prediction_df: pd.DataFrame,
+    validation_rows: pd.DataFrame,
+    rule_rows: pd.DataFrame,
+) -> pd.DataFrame:
+    aligned = prediction_df.merge(
+        validation_rows,
+        on=COMPARISON_KEY_COLUMNS,
+        how="inner",
+        validate="many_to_one",
+    )
+    if len(aligned) != len(prediction_df):
+        raise ValueError("Prediction log rows do not fully align to the official validation rows.")
+
+    aligned = aligned.merge(
+        rule_rows,
+        on=COMPARISON_KEY_COLUMNS,
+        how="inner",
+        validate="many_to_one",
+    )
+    if len(aligned) != len(prediction_df):
+        raise ValueError("Rule strategy outputs do not fully align to the official validation rows.")
+    if aligned.empty:
+        raise ValueError("Comparison alignment produced no overlapping rows.")
+
+    aligned["comparison_outcome"] = aligned.apply(_comparison_outcome, axis=1)
+    aligned["is_agreement"] = (aligned["predicted_class"] == aligned["rule_entry_signal"]).astype("int64")
+    aligned["is_disagreement"] = (1 - aligned["is_agreement"]).astype("int64")
+    aligned["ml_matches_actual_target"] = (aligned["predicted_class"] == aligned["actual_target"]).astype("int64")
+    aligned["rule_entry_matches_actual_target"] = (
+        aligned["rule_entry_signal"] == aligned["actual_target"]
+    ).astype("int64")
+    aligned["probability_distance_from_threshold"] = (
+        pd.to_numeric(aligned["predicted_probability"], errors="coerce") - 0.5
+    ).abs().astype("Float64")
+
+    aligned = aligned.sort_values(ALIGNED_SORT_ORDER).reset_index(drop=True)
+    return aligned.loc[:, ALIGNED_COMPARISON_COLUMNS]
+
+
+def _build_model_summary_rows(aligned_df: pd.DataFrame) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for model_name, model_rows in aligned_df.groupby("model_name", sort=True):
+        estimator = str(model_rows["estimator"].iloc[0])
+        outcome_counts = model_rows["comparison_outcome"].value_counts()
+        rule_action_counts = model_rows["rule_action"].value_counts()
+
+        rows.append(
+            {
+                "model_name": model_name,
+                "estimator": estimator,
+                "prediction_run_id": str(model_rows["prediction_run_id"].iloc[0]),
+                "training_run_id": str(model_rows["training_run_id"].iloc[0]),
+                "row_count": int(len(model_rows)),
+                "symbol_count": int(model_rows["symbol"].nunique()),
+                "agreement_rate": float(model_rows["is_agreement"].mean()),
+                "disagreement_rate": float(model_rows["is_disagreement"].mean()),
+                "shared_entry_count": int(outcome_counts.get("both_entry", 0)),
+                "ml_only_entry_count": int(outcome_counts.get("ml_only_entry", 0)),
+                "rule_only_entry_count": int(outcome_counts.get("rule_only_entry", 0)),
+                "shared_non_entry_count": int(outcome_counts.get("shared_non_entry", 0)),
+                "rule_buy_count": int(rule_action_counts.get("BUY", 0)),
+                "rule_sell_count": int(rule_action_counts.get("SELL", 0)),
+                "rule_hold_count": int(rule_action_counts.get("HOLD", 0)),
+                "model_positive_rate": float(model_rows["predicted_class"].mean()),
+                "rule_buy_rate": float(model_rows["rule_entry_signal"].mean()),
+                "rule_sell_rate": float((model_rows["rule_action"] == "SELL").mean()),
+                "rule_hold_rate": float((model_rows["rule_action"] == "HOLD").mean()),
+                "actual_positive_rate": float(model_rows["actual_target"].mean()),
+                "ml_accuracy_vs_actual": float(model_rows["ml_matches_actual_target"].mean()),
+                "rule_entry_accuracy_vs_actual": float(model_rows["rule_entry_matches_actual_target"].mean()),
+                "actual_positive_rate_both_entry": _mean_or_none(
+                    model_rows.loc[model_rows["comparison_outcome"] == "both_entry", "actual_target"]
+                ),
+                "actual_positive_rate_ml_only_entry": _mean_or_none(
+                    model_rows.loc[model_rows["comparison_outcome"] == "ml_only_entry", "actual_target"]
+                ),
+                "actual_positive_rate_rule_only_entry": _mean_or_none(
+                    model_rows.loc[model_rows["comparison_outcome"] == "rule_only_entry", "actual_target"]
+                ),
+                "actual_positive_rate_shared_non_entry": _mean_or_none(
+                    model_rows.loc[model_rows["comparison_outcome"] == "shared_non_entry", "actual_target"]
+                ),
+                "mean_predicted_probability": _mean_or_none(model_rows["predicted_probability"]),
+                "mean_predicted_probability_rule_buy": _mean_or_none(
+                    model_rows.loc[model_rows["rule_action"] == "BUY", "predicted_probability"]
+                ),
+                "mean_predicted_probability_rule_sell": _mean_or_none(
+                    model_rows.loc[model_rows["rule_action"] == "SELL", "predicted_probability"]
+                ),
+                "mean_predicted_probability_rule_hold": _mean_or_none(
+                    model_rows.loc[model_rows["rule_action"] == "HOLD", "predicted_probability"]
+                ),
+            }
+        )
+
+    return rows
+
+
+def _build_per_symbol_summary_rows(aligned_df: pd.DataFrame) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for (model_name, symbol), symbol_rows in aligned_df.groupby(["model_name", "symbol"], sort=True):
+        outcome_counts = symbol_rows["comparison_outcome"].value_counts()
+        rule_action_counts = symbol_rows["rule_action"].value_counts()
+        rows.append(
+            {
+                "model_name": model_name,
+                "symbol": symbol,
+                "row_count": int(len(symbol_rows)),
+                "agreement_rate": float(symbol_rows["is_agreement"].mean()),
+                "shared_entry_count": int(outcome_counts.get("both_entry", 0)),
+                "ml_only_entry_count": int(outcome_counts.get("ml_only_entry", 0)),
+                "rule_only_entry_count": int(outcome_counts.get("rule_only_entry", 0)),
+                "shared_non_entry_count": int(outcome_counts.get("shared_non_entry", 0)),
+                "rule_buy_count": int(rule_action_counts.get("BUY", 0)),
+                "rule_sell_count": int(rule_action_counts.get("SELL", 0)),
+                "rule_hold_count": int(rule_action_counts.get("HOLD", 0)),
+                "actual_positive_rate": float(symbol_rows["actual_target"].mean()),
+                "ml_accuracy_vs_actual": float(symbol_rows["ml_matches_actual_target"].mean()),
+                "rule_entry_accuracy_vs_actual": float(symbol_rows["rule_entry_matches_actual_target"].mean()),
+                "mean_predicted_probability": _mean_or_none(symbol_rows["predicted_probability"]),
+            }
+        )
+    return rows
+
+
+def _methodology_payload(
+    definition: OfficialM4MLVsRuleComparisonDefinition,
+) -> dict[str, Any]:
+    return {
+        "name": definition.methodology_name,
+        "comparison_level": "decision_row_signal",
+        "shared_key_columns": list(COMPARISON_KEY_COLUMNS),
+        "sort_order": list(ALIGNED_SORT_ORDER),
+        "ml_signal_definition": {
+            "source_column": "predicted_class",
+            "positive_label": 1,
+            "probability_column": "predicted_probability",
+            "meaning": "Predict next-session direction is positive for the same symbol row.",
+        },
+        "rule_signal_definition": {
+            "source": "DailySimulator signal_history from the live momentum strategy replay.",
+            "raw_action_column": "rule_action",
+            "comparison_signal_column": definition.comparison_signal_column,
+            "comparison_mapping": {"BUY": 1, "SELL": 0, "HOLD": 0},
+            "raw_actions_retained": ["BUY", "SELL", "HOLD"],
+        },
+        "alignment_policy": {
+            "prediction_rows_must_match_validation_rows_per_model": True,
+            "rule_rows_must_cover_all_validation_symbol_dates": True,
+            "duplicate_symbol_date_rows_fail": True,
+        },
+        "carryover_policy": (
+            "The rule strategy is replayed on the shared feature history for the comparison symbols through "
+            "the validation end date, then only validation decision rows are aligned to ML predictions."
+        ),
+        "time_safe_assumptions": [
+            "ML rows use official M4 prediction logs keyed by symbol/date/target_date.",
+            "Rule decisions are generated by the existing simulator using data available up to each decision date only.",
+            "The simulator strips target_ columns before strategy execution.",
+            "Rule orders continue to use next-session execution behavior during replay.",
+            "The aligned comparison keeps target_date strictly after date for every row.",
+        ],
+    }
+
+
+def run_m4_ml_vs_rule_comparison(
+    *,
+    predictions_path: Path,
+    metadata_path: Path | None = None,
+    config_path: Path = M4_ML_VS_RULE_COMPARISON_CONFIG_PATH,
+    comparison_definition: OfficialM4MLVsRuleComparisonDefinition | None = None,
+) -> dict[str, Any]:
+    resolved_definition = comparison_definition or load_m4_ml_vs_rule_comparison_definition(config_path)
+    prediction_log_definition = load_m4_prediction_log_definition()
+    resolved_metadata_path = metadata_path or predictions_path.with_name(prediction_log_definition.metadata_filename)
+    prediction_bundle = load_m4_prediction_log_bundle(
+        dataset_path=Path(predictions_path),
+        metadata_path=Path(resolved_metadata_path),
+        validate=True,
+    )
+    prediction_df = prediction_bundle["dataframe"].copy()
+    prediction_metadata = prediction_bundle["metadata"]
+    if prediction_metadata.get("pipeline_name") != "m4_model_output_logging":
+        raise ValueError("Prediction metadata is not an M4 model output logging artifact.")
+
+    source_artifacts = prediction_metadata.get("source_artifacts") or {}
+    training_summary_raw = str(source_artifacts.get("training_summary_path", "")).strip()
+    if not training_summary_raw:
+        raise ValueError("Prediction log metadata is missing source_artifacts.training_summary_path.")
+    training_summary_path = _resolve_repo_path(training_summary_raw)
+    training_bundle = load_m4_baseline_training_run_bundle(training_summary_path)
+
+    if str(prediction_df["training_run_id"].iloc[0]).strip() != str(training_bundle["training_summary"].get("run_id", "")).strip():
+        raise ValueError("Prediction log training_run_id does not match the referenced training summary.")
+
+    prepared = prepare_m4_baseline_training_data(
+        training_definition=training_bundle["training_definition"],
+        split_definition=training_bundle["split_definition"],
+        target_definition=training_bundle["target_definition"],
+    )
+    validation_rows = _build_validation_rows(
+        prepared["validation_dataframe"],
+        actual_target_column=training_bundle["training_definition"].target_column,
+        actual_return_column=training_bundle["target_definition"].helper_return_column,
+    )
+
+    _validate_prediction_rows(
+        prediction_df,
+        validation_rows=validation_rows,
+        expected_target_column=training_bundle["training_definition"].target_column,
+        expected_task_type=str(training_bundle["target_definition"].task_type).strip().lower(),
+    )
+
+    output_root = _resolve_repo_path(resolved_definition.output_dir)
+    manager = RunArtifactManager(
+        base_output_dir=output_root,
+        strategy_name=resolved_definition.strategy_name,
+        start_date=_format_date(validation_rows["date"].min()) or "",
+        end_date=_format_date(validation_rows["date"].max()) or "",
+        run_label=resolved_definition.run_label,
+        strategy_variant=resolved_definition.methodology_name,
+    )
+
+    config_snapshot = {
+        "comparison_definition": asdict(resolved_definition),
+        "predictions_path": str(Path(predictions_path).resolve()),
+        "prediction_metadata_path": str(Path(resolved_metadata_path).resolve()),
+        "training_summary_path": str(training_summary_path),
+        "prediction_run_id": str(prediction_df["prediction_run_id"].iloc[0]),
+        "training_run_id": str(prediction_df["training_run_id"].iloc[0]),
+        "recreated_split_definition": asdict(training_bundle["split_definition"]),
+        "recreated_target_definition": asdict(training_bundle["target_definition"]),
+    }
+    config_snapshot_path = manager.write_config_snapshot(config_snapshot)
+
+    try:
+        strategy_config_path = _resolve_repo_path(resolved_definition.strategy_config_path)
+        feature_dataset_path = _resolve_repo_path(resolved_definition.feature_dataset_path)
+        rule_settings = _load_rule_settings(strategy_config_path)
+        comparison_symbols = (
+            validation_rows["symbol"].dropna().astype(str).str.upper().sort_values().unique().tolist()
+        )
+        rule_feature_history = _load_rule_feature_history(
+            feature_dataset_path=feature_dataset_path,
+            comparison_symbols=comparison_symbols,
+            validation_rows=validation_rows,
+        )
+        rule_replay_result = _run_rule_strategy_replay(
+            feature_history=rule_feature_history,
+            settings=rule_settings,
+            comparison_run_id=manager.run_id,
+            comparison_dir=manager.output_dir,
+            config_source=strategy_config_path,
+        )
+        rule_rows = _build_rule_signal_rows(
+            signal_history=rule_replay_result["signal_history"],
+            validation_rows=validation_rows,
+        )
+        aligned_df = _build_aligned_comparison_table(
+            prediction_df=prediction_df,
+            validation_rows=validation_rows,
+            rule_rows=rule_rows,
+        )
+        model_summary_rows = _build_model_summary_rows(aligned_df)
+        per_symbol_summary_rows = _build_per_symbol_summary_rows(aligned_df)
+
+        aligned_path = manager.artifact_path(ALIGNED_COMPARISON_FILENAME)
+        aligned_df.to_parquet(aligned_path, index=False)
+        manager.register_artifact("aligned_comparison", aligned_path)
+
+        summary_df = pd.DataFrame(model_summary_rows, columns=SUMMARY_ROW_COLUMNS)
+        summary_csv_path = manager.artifact_path(COMPARISON_SUMMARY_CSV_FILENAME)
+        summary_df.to_csv(summary_csv_path, index=False)
+        manager.register_artifact("summary_csv", summary_csv_path)
+
+        per_symbol_df = pd.DataFrame(per_symbol_summary_rows, columns=PER_SYMBOL_SUMMARY_COLUMNS)
+        per_symbol_csv_path = manager.artifact_path(PER_SYMBOL_SUMMARY_CSV_FILENAME)
+        per_symbol_df.to_csv(per_symbol_csv_path, index=False)
+        manager.register_artifact("per_symbol_summary_csv", per_symbol_csv_path)
+
+        methodology = _methodology_payload(resolved_definition)
+        validation_signature = build_dataframe_signature(validation_rows)
+        aligned_signature = build_dataframe_signature(aligned_df)
+
+        aligned_metadata = {
+            "pipeline_name": "m4_ml_vs_rule_comparison",
+            "pipeline_version": PIPELINE_VERSION,
+            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "entrypoint": ENTRYPOINT,
+            "comparison_run_id": manager.run_id,
+            "comparison_definition": asdict(resolved_definition),
+            "methodology": methodology,
+            "prediction_source": {
+                "predictions_path": str(Path(predictions_path).resolve()),
+                "prediction_metadata_path": str(Path(resolved_metadata_path).resolve()),
+                "prediction_run_id": str(prediction_df["prediction_run_id"].iloc[0]),
+                "training_run_id": str(prediction_df["training_run_id"].iloc[0]),
+                "prediction_output_signature": str(
+                    (prediction_metadata.get("output_log") or {}).get("output_signature", "")
+                ).strip(),
+                "model_count": int(prediction_df["model_name"].nunique()),
+                "models": [
+                    {
+                        "model_name": str(model_name),
+                        "estimator": str(group["estimator"].iloc[0]),
+                        "model_artifact_path": str(group["model_artifact_path"].iloc[0]),
+                        "model_metadata_path": str(group["model_metadata_path"].iloc[0]),
+                    }
+                    for model_name, group in prediction_df.groupby("model_name", sort=True)
+                ],
+            },
+            "training_source": {
+                "training_summary_path": str(training_summary_path),
+                "training_run_id": str(training_bundle["training_summary"].get("run_id", "")),
+                "training_output_dir": str(training_bundle["training_run_dir"]),
+                "feature_schema_path": str(training_bundle["feature_schema_path"]),
+                "split_summary_path": str(training_bundle["split_summary_path"]),
+                "validation_dataset_signature": validation_signature,
+            },
+            "rule_strategy": {
+                "strategy_config_path": str(strategy_config_path),
+                "feature_dataset_path": str(feature_dataset_path),
+                "feature_history_row_count": int(len(rule_feature_history)),
+                "feature_history_start_date": _format_date(rule_feature_history["date"].min()),
+                "feature_history_end_date": _format_date(rule_feature_history["date"].max()),
+                "strategy_name": str((rule_settings.get("strategy") or {}).get("name", "momentum_v0")),
+                "strategy_parameters": {
+                    "max_open_positions": int((rule_settings.get("portfolio") or {}).get("max_open_positions", 1)),
+                    "top_k": int((rule_settings.get("strategy") or {}).get("top_k", 1)),
+                    "min_score": float((rule_settings.get("strategy") or {}).get("min_score", 0.0)),
+                    "min_volume_ratio": float((rule_settings.get("strategy") or {}).get("min_volume_ratio", 0.8)),
+                },
+                "portfolio_parameters": {
+                    "initial_cash": float((rule_settings.get("portfolio") or {}).get("initial_cash", 0.0)),
+                    "fractional_shares": bool((rule_settings.get("portfolio") or {}).get("fractional_shares", True)),
+                },
+                "execution_parameters": {
+                    "commission_rate": float((rule_settings.get("execution") or {}).get("commission_rate", 0.0)),
+                    "slippage_rate": float((rule_settings.get("execution") or {}).get("slippage_rate", 0.0)),
+                    "execution_timing": str((rule_settings.get("execution") or {}).get("execution_timing", "")),
+                },
+                "benchmark_symbol": str((rule_settings.get("benchmark") or {}).get("benchmark_symbol", "")),
+                "rule_replay_run_id": str(rule_replay_result["run_id"]),
+                "rule_replay_output_dir": str(rule_replay_result["output_dir"]),
+                "rule_replay_manifest_path": str(rule_replay_result["manifest_path"]),
+            },
+            "validation_dataset": {
+                "row_count": int(len(validation_rows)),
+                "symbol_count": int(validation_rows["symbol"].nunique()),
+                "feature_date_start": _format_date(validation_rows["date"].min()),
+                "feature_date_end": _format_date(validation_rows["date"].max()),
+                "target_date_start": _format_date(validation_rows["target_date"].min()),
+                "target_date_end": _format_date(validation_rows["target_date"].max()),
+                "shared_key_columns": list(COMPARISON_KEY_COLUMNS),
+                "actual_target_column": training_bundle["training_definition"].target_column,
+                "actual_target_return_column": training_bundle["target_definition"].helper_return_column,
+                "validation_dataset_signature": validation_signature,
+            },
+            "aligned_output": {
+                "path": str(aligned_path),
+                "row_count": int(len(aligned_df)),
+                "columns": list(aligned_df.columns),
+                "sort_order": list(ALIGNED_SORT_ORDER),
+                "output_signature": aligned_signature,
+                "summary_csv_path": str(summary_csv_path),
+                "per_symbol_summary_csv_path": str(per_symbol_csv_path),
+            },
+            "summary_rows": model_summary_rows,
+        }
+        aligned_metadata_path = _write_json(
+            manager.artifact_path(ALIGNED_COMPARISON_METADATA_FILENAME),
+            aligned_metadata,
+        )
+        manager.register_artifact("aligned_comparison_metadata", aligned_metadata_path)
+
+        summary_payload = {
+            "pipeline_name": "m4_ml_vs_rule_comparison",
+            "pipeline_version": PIPELINE_VERSION,
+            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "entrypoint": ENTRYPOINT,
+            "comparison_run_id": manager.run_id,
+            "status": "completed",
+            "config_snapshot_path": str(config_snapshot_path),
+            "methodology": methodology,
+            "prediction_run_id": str(prediction_df["prediction_run_id"].iloc[0]),
+            "training_run_id": str(prediction_df["training_run_id"].iloc[0]),
+            "validation_dataset": aligned_metadata["validation_dataset"],
+            "rule_strategy": {
+                "strategy_name": aligned_metadata["rule_strategy"]["strategy_name"],
+                "strategy_config_path": aligned_metadata["rule_strategy"]["strategy_config_path"],
+                "feature_dataset_path": aligned_metadata["rule_strategy"]["feature_dataset_path"],
+                "rule_replay_run_id": aligned_metadata["rule_strategy"]["rule_replay_run_id"],
+                "rule_replay_output_dir": aligned_metadata["rule_strategy"]["rule_replay_output_dir"],
+                "rule_replay_manifest_path": aligned_metadata["rule_strategy"]["rule_replay_manifest_path"],
+            },
+            "artifacts": {
+                "aligned_comparison_path": str(aligned_path),
+                "aligned_comparison_metadata_path": str(aligned_metadata_path),
+                "summary_csv_path": str(summary_csv_path),
+                "per_symbol_summary_csv_path": str(per_symbol_csv_path),
+            },
+            "rows": model_summary_rows,
+        }
+        summary_json_path = _write_json(
+            manager.artifact_path(COMPARISON_SUMMARY_JSON_FILENAME),
+            summary_payload,
+        )
+        manager.register_artifact("summary_json", summary_json_path)
+        manager.register_artifact("rule_replay_manifest", Path(rule_replay_result["manifest_path"]))
+
+        manifest_path = manager.write_manifest(status="completed", config_source=str(config_path))
+    except Exception as exc:
+        manifest_path = manager.write_manifest(
+            status="failed",
+            config_source=str(config_path),
+            error_message=str(exc),
+        )
+        raise
+
+    return {
+        "run_id": manager.run_id,
+        "output_dir": manager.output_dir,
+        "manifest_path": manifest_path,
+        "config_path": config_snapshot_path,
+        "aligned_path": aligned_path,
+        "aligned_metadata_path": aligned_metadata_path,
+        "summary_json_path": summary_json_path,
+        "summary_csv_path": summary_csv_path,
+        "per_symbol_summary_csv_path": per_symbol_csv_path,
+        "rule_replay_run_id": rule_replay_result["run_id"],
+        "rule_replay_output_dir": rule_replay_result["output_dir"],
+        "rule_replay_manifest_path": rule_replay_result["manifest_path"],
+        "rows": model_summary_rows,
+    }

--- a/src/engine/ml_vs_rule_comparison.py
+++ b/src/engine/ml_vs_rule_comparison.py
@@ -833,6 +833,22 @@ def run_m4_ml_vs_rule_comparison(
         actual_target_column=training_bundle["training_definition"].target_column,
         actual_return_column=training_bundle["target_definition"].helper_return_column,
     )
+    summary_split = training_bundle["training_summary"].get("official_split", {}).get("summary", {})
+    expected_validation_signature = str(
+        training_bundle["split_summary"].get("validation_dataset_signature")
+        or summary_split.get("validation_dataset_signature")
+        or ""
+    ).strip()
+    if not expected_validation_signature:
+        raise ValueError(
+            "Training artifacts are missing validation_dataset_signature; rerun baseline training to "
+            "enable immutable validation dataset checks."
+        )
+    rebuilt_validation_signature = build_dataframe_signature(prepared["validation_dataframe"])
+    if rebuilt_validation_signature != expected_validation_signature:
+        raise ValueError(
+            "Rebuilt validation partition signature does not match the stored training artifacts."
+        )
 
     _validate_prediction_rows(
         prediction_df,

--- a/src/engine/test_m4_ml_vs_rule_comparison_config.py
+++ b/src/engine/test_m4_ml_vs_rule_comparison_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from src.data.loader import load_yaml
+from src.engine.ml_vs_rule_comparison import load_m4_ml_vs_rule_comparison_definition
+
+
+class M4MLVsRuleComparisonConfigTests(unittest.TestCase):
+    def test_official_m4_ml_vs_rule_comparison_config_matches_expected_contract(self) -> None:
+        config_path = Path("config/evaluation/m4_ml_vs_rule_comparison.yaml")
+        self.assertTrue(config_path.exists(), f"Missing ML-vs-rule comparison config file: {config_path}")
+
+        data = load_yaml(config_path)
+        self.assertIn("comparison", data)
+
+        definition = load_m4_ml_vs_rule_comparison_definition(config_path)
+        self.assertEqual(definition.milestone, "M4")
+        self.assertEqual(definition.contract_name, "m4_official_ml_vs_rule_comparison")
+        self.assertEqual(definition.training_config_path, "config/modeling/m4_baselines.yaml")
+        self.assertEqual(definition.prediction_config_path, "config/evaluation/m4_batch_prediction.yaml")
+        self.assertEqual(definition.prediction_log_config_path, "config/modeling/m4_prediction_logs.yaml")
+        self.assertEqual(definition.strategy_config_path, "config/settings.yaml")
+        self.assertEqual(definition.feature_dataset_path, "data/processed/market_features.parquet")
+        self.assertEqual(definition.output_dir, "outputs/reports/ml_vs_rule_comparisons")
+        self.assertEqual(definition.strategy_name, "M4MLVsRuleComparison")
+        self.assertEqual(definition.run_label, "m4-ml-vs-rule-comparison")
+        self.assertEqual(definition.methodology_name, "validation_signal_alignment")
+        self.assertEqual(definition.comparison_signal_column, "rule_entry_signal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/engine/test_ml_vs_rule_comparison.py
+++ b/src/engine/test_ml_vs_rule_comparison.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+import pandas as pd
+
+from src.data.modeling_dataset import (
+    get_m4_modeling_dataset_column_order,
+    get_m4_modeling_feature_columns,
+    load_m4_modeling_dataset_definition,
+    normalize_m4_modeling_dataset,
+)
+from src.data.splits import load_m4_split_definition
+from src.data.targets import load_m4_target_definition
+from src.engine.ml_vs_rule_comparison import (
+    load_m4_ml_vs_rule_comparison_definition,
+    run_m4_ml_vs_rule_comparison,
+)
+from src.engine.prediction_pipeline import (
+    load_m4_batch_prediction_definition,
+    run_m4_batch_prediction,
+)
+from src.strategy.ml_baselines import (
+    build_dataframe_signature,
+    load_m4_baseline_training_definition,
+    run_m4_baseline_training,
+)
+
+
+class M4MLVsRuleComparisonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataset_definition = load_m4_modeling_dataset_definition()
+        self.target_definition = load_m4_target_definition()
+        self.training_definition = load_m4_baseline_training_definition()
+        self.prediction_definition = load_m4_batch_prediction_definition()
+        self.comparison_definition = load_m4_ml_vs_rule_comparison_definition()
+        self.split_definition = replace(
+            load_m4_split_definition(),
+            validation_start_date="2024-01-09",
+            validation_end_date="2024-01-10",
+        )
+        self.feature_columns = get_m4_modeling_feature_columns(self.dataset_definition)
+
+    def _build_feature_and_modeling_datasets(self) -> tuple[pd.DataFrame, pd.DataFrame]:
+        business_dates = pd.bdate_range("2024-01-02", periods=6)
+        plan = {
+            "AAA": [
+                {"adj_close": 99.0, "ma20": 100.0, "ma50": 101.0, "ret5d": -0.05, "volr": 0.70, "target": 0},
+                {"adj_close": 99.0, "ma20": 100.0, "ma50": 101.0, "ret5d": 0.02, "volr": 1.00, "target": 1},
+                {"adj_close": 104.0, "ma20": 100.0, "ma50": 98.0, "ret5d": 0.06, "volr": 1.20, "target": 1},
+                {"adj_close": 105.0, "ma20": 101.0, "ma50": 99.0, "ret5d": 0.05, "volr": 1.10, "target": 1},
+                {"adj_close": 106.0, "ma20": 102.0, "ma50": 100.0, "ret5d": 0.04, "volr": 1.00, "target": 0},
+                {"adj_close": 100.0, "ma20": 103.0, "ma50": 101.0, "ret5d": -0.03, "volr": 0.90, "target": 0},
+            ],
+            "BBB": [
+                {"adj_close": 49.0, "ma20": 50.0, "ma50": 52.0, "ret5d": -0.02, "volr": 0.90, "target": 0},
+                {"adj_close": 50.0, "ma20": 51.0, "ma50": 52.0, "ret5d": -0.01, "volr": 0.90, "target": 0},
+                {"adj_close": 51.0, "ma20": 52.0, "ma50": 53.0, "ret5d": 0.01, "volr": 0.90, "target": 0},
+                {"adj_close": 52.0, "ma20": 53.0, "ma50": 54.0, "ret5d": 0.02, "volr": 0.90, "target": 0},
+                {"adj_close": 58.0, "ma20": 54.0, "ma50": 52.0, "ret5d": 0.07, "volr": 1.30, "target": 1},
+                {"adj_close": 59.0, "ma20": 55.0, "ma50": 53.0, "ret5d": 0.06, "volr": 1.10, "target": 1},
+            ],
+        }
+
+        feature_rows: list[dict[str, object]] = []
+        modeling_rows: list[dict[str, object]] = []
+        for symbol_index, symbol in enumerate(["AAA", "BBB"]):
+            for row_index, decision_date in enumerate(business_dates):
+                raw = plan[symbol][row_index]
+                adj_close = float(raw["adj_close"])
+                ma20 = float(raw["ma20"])
+                ma50 = float(raw["ma50"])
+                ret5d = float(raw["ret5d"])
+                volume_ratio = float(raw["volr"])
+                volume = 1_000_000.0 + (symbol_index * 50_000.0) + (row_index * 1_000.0)
+                volume_ma20 = volume / volume_ratio
+                ma10 = ma20 + 1.0
+                rolling_high = adj_close + 5.0
+                rolling_low = adj_close - 5.0
+                range_pos = (adj_close - rolling_low) / (rolling_high - rolling_low)
+
+                base_row: dict[str, object] = {
+                    "date": decision_date,
+                    "symbol": symbol,
+                    "open": adj_close - 1.0,
+                    "high": adj_close + 1.0,
+                    "low": adj_close - 2.0,
+                    "close": adj_close - 0.5,
+                    "adj_close": adj_close,
+                    "volume": volume,
+                    "dividends": 0.0,
+                    "stock_splits": 0.0,
+                    "ret_1d": ret5d / 5.0,
+                    "ret_5d": ret5d,
+                    "ret_10d": ret5d / 2.0,
+                    "ma_10": ma10,
+                    "ma_20": ma20,
+                    "ma_50": ma50,
+                    "vol_20": 0.02 + (row_index * 0.001),
+                    "volume_change_1d": 0.01 if ret5d > 0 else -0.01,
+                    "volume_ma_20": volume_ma20,
+                    "volume_ratio_20": volume_ratio,
+                    "price_vs_ma10": (adj_close / ma10) - 1.0,
+                    "price_vs_ma20": (adj_close / ma20) - 1.0,
+                    "price_vs_ma50": (adj_close / ma50) - 1.0,
+                    "ma10_vs_ma20": (ma10 / ma20) - 1.0,
+                    "ma20_vs_ma50": (ma20 / ma50) - 1.0,
+                    "rolling_high_20": rolling_high,
+                    "rolling_low_20": rolling_low,
+                    "range_pos_20": range_pos,
+                }
+                feature_rows.append(dict(base_row))
+
+                modeling_row = dict(base_row)
+                target_value = int(raw["target"])
+                modeling_row["target_date"] = decision_date + pd.offsets.BDay(1)
+                modeling_row["target_is_valid"] = True
+                modeling_row["target_next_session_return"] = 0.02 if target_value == 1 else -0.02
+                modeling_row["target_next_session_direction"] = target_value
+                modeling_rows.append(modeling_row)
+
+        feature_df = pd.DataFrame(feature_rows).loc[:, ["date", "symbol", *self.feature_columns]]
+        feature_df = feature_df.sample(frac=1.0, random_state=23).reset_index(drop=True)
+
+        modeling_df = pd.DataFrame(modeling_rows)
+        modeling_df = modeling_df.loc[
+            :,
+            get_m4_modeling_dataset_column_order(self.dataset_definition, self.target_definition),
+        ]
+        modeling_df = modeling_df.sample(frac=1.0, random_state=29).reset_index(drop=True)
+        modeling_df = normalize_m4_modeling_dataset(
+            modeling_df,
+            dataset_definition=self.dataset_definition,
+            target_definition=self.target_definition,
+        )
+        return feature_df, modeling_df
+
+    def _write_input_artifacts(
+        self,
+        tmp_path: Path,
+    ) -> tuple[Path, Path, Path, Path]:
+        feature_df, modeling_df = self._build_feature_and_modeling_datasets()
+        feature_dataset_path = tmp_path / "market_features.parquet"
+        modeling_dataset_path = tmp_path / "m4_modeling_dataset.parquet"
+        modeling_metadata_path = tmp_path / "m4_modeling_dataset.metadata.json"
+        settings_path = tmp_path / "settings.yaml"
+
+        feature_df.to_parquet(feature_dataset_path, index=False)
+        modeling_df.to_parquet(modeling_dataset_path, index=False)
+        modeling_metadata_path.write_text("{}", encoding="utf-8")
+        settings_path.write_text(
+            "\n".join(
+                [
+                    "project:",
+                    "  name: ml-vs-rule-test",
+                    "strategy:",
+                    "  name: momentum_v0",
+                    "  top_k: 2",
+                    "  min_score: 0.0",
+                    "  min_volume_ratio: 0.8",
+                    "portfolio:",
+                    "  initial_cash: 500.0",
+                    "  max_open_positions: 2",
+                    "  fractional_shares: true",
+                    "execution:",
+                    "  commission_rate: 0.001",
+                    "  slippage_rate: 0.001",
+                    "  execution_timing: next_open",
+                    "benchmark:",
+                    '  benchmark_symbol: ""',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return feature_dataset_path, modeling_dataset_path, modeling_metadata_path, settings_path
+
+    def _run_comparison_fixture(
+        self,
+        tmp_path: Path,
+    ) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+        feature_dataset_path, modeling_dataset_path, modeling_metadata_path, settings_path = self._write_input_artifacts(
+            tmp_path
+        )
+        training_definition = replace(
+            self.training_definition,
+            modeling_dataset_path=str(modeling_dataset_path),
+            modeling_dataset_metadata_path=str(modeling_metadata_path),
+            output_dir=str(tmp_path / "outputs" / "models"),
+            split_metadata_path=str(tmp_path / "m4_train_validation_split.metadata.json"),
+        )
+        training_result = run_m4_baseline_training(
+            training_definition=training_definition,
+            split_definition=self.split_definition,
+            target_definition=self.target_definition,
+        )
+
+        prediction_definition = replace(
+            self.prediction_definition,
+            output_dir=str(tmp_path / "outputs" / "predictions" / "model_batches"),
+        )
+        prediction_result = run_m4_batch_prediction(
+            training_summary_path=Path(str(training_result["training_summary_path"])),
+            prediction_definition=prediction_definition,
+        )
+
+        comparison_definition = replace(
+            self.comparison_definition,
+            output_dir=str(tmp_path / "outputs" / "reports" / "ml_vs_rule_comparisons"),
+            strategy_config_path=str(settings_path),
+            feature_dataset_path=str(feature_dataset_path),
+        )
+        comparison_result = run_m4_ml_vs_rule_comparison(
+            predictions_path=Path(str(prediction_result["predictions_path"])),
+            metadata_path=Path(str(prediction_result["prediction_log_metadata_path"])),
+            comparison_definition=comparison_definition,
+        )
+        return training_result, prediction_result, comparison_result
+
+    def _expected_rule_alignment(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {
+                    "symbol": "AAA",
+                    "date": pd.Timestamp("2024-01-08"),
+                    "target_date": pd.Timestamp("2024-01-09"),
+                    "rule_action": "HOLD",
+                    "rule_entry_signal": 0,
+                    "rule_exit_signal": 0,
+                    "rule_schedule_status": "NO_SIGNAL",
+                },
+                {
+                    "symbol": "AAA",
+                    "date": pd.Timestamp("2024-01-09"),
+                    "target_date": pd.Timestamp("2024-01-10"),
+                    "rule_action": "SELL",
+                    "rule_entry_signal": 0,
+                    "rule_exit_signal": 1,
+                    "rule_schedule_status": "NO_NEXT_TRADING_SESSION",
+                },
+                {
+                    "symbol": "BBB",
+                    "date": pd.Timestamp("2024-01-08"),
+                    "target_date": pd.Timestamp("2024-01-09"),
+                    "rule_action": "BUY",
+                    "rule_entry_signal": 1,
+                    "rule_exit_signal": 0,
+                    "rule_schedule_status": "SCHEDULED",
+                },
+                {
+                    "symbol": "BBB",
+                    "date": pd.Timestamp("2024-01-09"),
+                    "target_date": pd.Timestamp("2024-01-10"),
+                    "rule_action": "HOLD",
+                    "rule_entry_signal": 0,
+                    "rule_exit_signal": 0,
+                    "rule_schedule_status": "NO_SIGNAL",
+                },
+            ]
+        )
+
+    def test_comparison_aligns_prediction_rows_with_rule_strategy_replay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, _, comparison_result = self._run_comparison_fixture(tmp_path)
+
+            self.assertTrue(Path(str(comparison_result["output_dir"])).exists())
+            self.assertTrue(Path(str(comparison_result["manifest_path"])).exists())
+            self.assertTrue(Path(str(comparison_result["aligned_path"])).exists())
+            self.assertTrue(Path(str(comparison_result["aligned_metadata_path"])).exists())
+            self.assertTrue(Path(str(comparison_result["summary_json_path"])).exists())
+
+            aligned_df = pd.read_parquet(comparison_result["aligned_path"])
+            self.assertEqual(len(aligned_df), 8)
+            expected_rule_rows = self._expected_rule_alignment()
+
+            for model_name in sorted(aligned_df["model_name"].unique().tolist()):
+                observed = (
+                    aligned_df.loc[
+                        aligned_df["model_name"] == model_name,
+                        [
+                            "symbol",
+                            "date",
+                            "target_date",
+                            "rule_action",
+                            "rule_entry_signal",
+                            "rule_exit_signal",
+                            "rule_schedule_status",
+                        ],
+                    ]
+                    .sort_values(["symbol", "date"])
+                    .reset_index(drop=True)
+                )
+                pd.testing.assert_frame_equal(observed, expected_rule_rows)
+
+            summary = json.loads(Path(str(comparison_result["summary_json_path"])).read_text(encoding="utf-8"))
+            self.assertEqual(summary["validation_dataset"]["row_count"], 4)
+            self.assertEqual(summary["methodology"]["name"], "validation_signal_alignment")
+            self.assertTrue(Path(summary["rule_strategy"]["rule_replay_manifest_path"]).exists())
+
+    def test_summary_metrics_match_aligned_artifact_and_are_reloadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, _, comparison_result = self._run_comparison_fixture(tmp_path)
+
+            aligned_df = pd.read_parquet(comparison_result["aligned_path"])
+            summary_csv = pd.read_csv(comparison_result["summary_csv_path"]).sort_values("model_name").reset_index(drop=True)
+            metadata = json.loads(Path(str(comparison_result["aligned_metadata_path"])).read_text(encoding="utf-8"))
+
+            self.assertEqual(metadata["aligned_output"]["row_count"], len(aligned_df))
+            self.assertEqual(metadata["aligned_output"]["output_signature"], build_dataframe_signature(aligned_df))
+
+            for _, row in summary_csv.iterrows():
+                group = aligned_df.loc[aligned_df["model_name"] == row["model_name"]].copy()
+                self.assertEqual(int(row["row_count"]), len(group))
+                self.assertEqual(int(row["symbol_count"]), group["symbol"].nunique())
+                self.assertAlmostEqual(float(row["agreement_rate"]), float(group["is_agreement"].mean()))
+                self.assertAlmostEqual(float(row["disagreement_rate"]), float(group["is_disagreement"].mean()))
+                self.assertEqual(int(row["shared_entry_count"]), int((group["comparison_outcome"] == "both_entry").sum()))
+                self.assertEqual(int(row["ml_only_entry_count"]), int((group["comparison_outcome"] == "ml_only_entry").sum()))
+                self.assertEqual(int(row["rule_only_entry_count"]), int((group["comparison_outcome"] == "rule_only_entry").sum()))
+                self.assertEqual(int(row["shared_non_entry_count"]), int((group["comparison_outcome"] == "shared_non_entry").sum()))
+                self.assertEqual(int(row["rule_buy_count"]), int((group["rule_action"] == "BUY").sum()))
+                self.assertEqual(int(row["rule_sell_count"]), int((group["rule_action"] == "SELL").sum()))
+                self.assertEqual(int(row["rule_hold_count"]), int((group["rule_action"] == "HOLD").sum()))
+
+    def test_repeated_runs_with_same_inputs_produce_identical_comparison_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, prediction_result, first = self._run_comparison_fixture(tmp_path)
+
+            comparison_definition = replace(
+                self.comparison_definition,
+                output_dir=str(tmp_path / "outputs" / "reports" / "ml_vs_rule_comparisons"),
+                strategy_config_path=str(tmp_path / "settings.yaml"),
+                feature_dataset_path=str(tmp_path / "market_features.parquet"),
+            )
+            second = run_m4_ml_vs_rule_comparison(
+                predictions_path=Path(str(prediction_result["predictions_path"])),
+                metadata_path=Path(str(prediction_result["prediction_log_metadata_path"])),
+                comparison_definition=comparison_definition,
+            )
+
+            first_aligned = pd.read_parquet(first["aligned_path"])
+            second_aligned = pd.read_parquet(second["aligned_path"])
+            pd.testing.assert_frame_equal(first_aligned, second_aligned)
+
+            first_summary = pd.read_csv(first["summary_csv_path"]).sort_values("model_name").reset_index(drop=True)
+            second_summary = pd.read_csv(second["summary_csv_path"]).sort_values("model_name").reset_index(drop=True)
+            pd.testing.assert_frame_equal(first_summary, second_summary)
+
+            first_symbol_summary = pd.read_csv(first["per_symbol_summary_csv_path"]).sort_values(["model_name", "symbol"]).reset_index(drop=True)
+            second_symbol_summary = pd.read_csv(second["per_symbol_summary_csv_path"]).sort_values(["model_name", "symbol"]).reset_index(drop=True)
+            pd.testing.assert_frame_equal(first_symbol_summary, second_symbol_summary)
+
+    def test_prediction_alignment_mismatch_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, prediction_result, _ = self._run_comparison_fixture(tmp_path)
+
+            prediction_path = Path(str(prediction_result["predictions_path"]))
+            corrupted = pd.read_parquet(prediction_path)
+            corrupted = corrupted.iloc[1:].reset_index(drop=True)
+            corrupted.to_parquet(prediction_path, index=False)
+
+            comparison_definition = replace(
+                self.comparison_definition,
+                output_dir=str(tmp_path / "outputs" / "reports" / "ml_vs_rule_comparisons"),
+                strategy_config_path=str(tmp_path / "settings.yaml"),
+                feature_dataset_path=str(tmp_path / "market_features.parquet"),
+            )
+            with self.assertRaisesRegex(ValueError, "do not match the official validation row count"):
+                run_m4_ml_vs_rule_comparison(
+                    predictions_path=prediction_path,
+                    metadata_path=Path(str(prediction_result["prediction_log_metadata_path"])),
+                    comparison_definition=comparison_definition,
+                )
+
+    def test_missing_feature_dataset_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, prediction_result, _ = self._run_comparison_fixture(tmp_path)
+
+            comparison_definition = replace(
+                self.comparison_definition,
+                output_dir=str(tmp_path / "outputs" / "reports" / "ml_vs_rule_comparisons"),
+                strategy_config_path=str(tmp_path / "settings.yaml"),
+                feature_dataset_path=str(tmp_path / "missing_market_features.parquet"),
+            )
+            with self.assertRaisesRegex(FileNotFoundError, "Missing rule feature dataset"):
+                run_m4_ml_vs_rule_comparison(
+                    predictions_path=Path(str(prediction_result["predictions_path"])),
+                    metadata_path=Path(str(prediction_result["prediction_log_metadata_path"])),
+                    comparison_definition=comparison_definition,
+                )
+
+    def test_summary_captures_decision_oriented_disagreement_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _, _, comparison_result = self._run_comparison_fixture(tmp_path)
+
+            summary = json.loads(Path(str(comparison_result["summary_json_path"])).read_text(encoding="utf-8"))
+            self.assertEqual(len(summary["rows"]), 2)
+            for row in summary["rows"]:
+                self.assertIn("actual_positive_rate_ml_only_entry", row)
+                self.assertIn("actual_positive_rate_rule_only_entry", row)
+                self.assertIn("rule_sell_count", row)
+                self.assertIn("ml_accuracy_vs_actual", row)
+                self.assertIn("rule_entry_accuracy_vs_actual", row)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/engine/test_ml_vs_rule_comparison.py
+++ b/src/engine/test_ml_vs_rule_comparison.py
@@ -398,6 +398,55 @@ class M4MLVsRuleComparisonTests(unittest.TestCase):
                     comparison_definition=comparison_definition,
                 )
 
+    def test_comparison_fails_when_validation_dataset_signature_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            feature_dataset_path, modeling_dataset_path, modeling_metadata_path, settings_path = self._write_input_artifacts(
+                tmp_path
+            )
+            training_definition = replace(
+                self.training_definition,
+                modeling_dataset_path=str(modeling_dataset_path),
+                modeling_dataset_metadata_path=str(modeling_metadata_path),
+                output_dir=str(tmp_path / "outputs" / "models"),
+                split_metadata_path=str(tmp_path / "m4_train_validation_split.metadata.json"),
+            )
+            training_result = run_m4_baseline_training(
+                training_definition=training_definition,
+                split_definition=self.split_definition,
+                target_definition=self.target_definition,
+            )
+            prediction_definition = replace(
+                self.prediction_definition,
+                output_dir=str(tmp_path / "outputs" / "predictions" / "model_batches"),
+            )
+            prediction_result = run_m4_batch_prediction(
+                training_summary_path=Path(str(training_result["training_summary_path"])),
+                prediction_definition=prediction_definition,
+            )
+
+            mutated_modeling_df = pd.read_parquet(modeling_dataset_path)
+            validation_mask = pd.to_datetime(mutated_modeling_df["target_date"]) == pd.Timestamp("2024-01-09")
+            mutated_modeling_df.loc[validation_mask, "target_next_session_direction"] = 1
+            mutated_modeling_df.loc[validation_mask, "target_next_session_return"] = 0.02
+            mutated_modeling_df.to_parquet(modeling_dataset_path, index=False)
+
+            comparison_definition = replace(
+                self.comparison_definition,
+                output_dir=str(tmp_path / "outputs" / "reports" / "ml_vs_rule_comparisons"),
+                strategy_config_path=str(settings_path),
+                feature_dataset_path=str(feature_dataset_path),
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "Rebuilt validation partition signature does not match the stored training artifacts",
+            ):
+                run_m4_ml_vs_rule_comparison(
+                    predictions_path=Path(str(prediction_result["predictions_path"])),
+                    metadata_path=Path(str(prediction_result["prediction_log_metadata_path"])),
+                    comparison_definition=comparison_definition,
+                )
+
     def test_summary_captures_decision_oriented_disagreement_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)


### PR DESCRIPTION
Closes #73

## What changed
- added a comparison workflow between baseline ML outputs and the existing rule-based strategy
- aligned ML predictions and rule-based outputs under shared time-safe assumptions
- saved structured comparison artifacts and summary metrics
- highlighted where model and rule-based behavior agree or differ
- prepared the comparison outputs for later simulation integration decisions

## Why
This PR adds the direct ML-vs-rule comparison needed to judge whether the first M4 modeling layer is meaningfully informative relative to the current handcrafted strategy.

## Notes
The comparison is intentionally lightweight and starts at the output level so later simulation-level integration can build on a clear and reproducible baseline.